### PR TITLE
Feat: Adding AGW deployment from deb package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Intended use case
 
 The Snap in this repository is specifically developed for the
-[Magma](https://www.magmacore.org/) usecase.
+[Magma](https://www.magmacore.org/) use case.
 
 ## Developing and testing
 

--- a/magma_access_gateway_installer/agw_installation_errors.py
+++ b/magma_access_gateway_installer/agw_installation_errors.py
@@ -4,11 +4,7 @@
 
 import logging
 
-from systemd.journal import JournalHandler  # type: ignore[import]
-
-logger = logging.getLogger(__name__)
-logger.addHandler(JournalHandler())
-logger.setLevel(logging.INFO)
+logger = logging.getLogger("magma_access_gateway_installer")
 
 
 class AGWInstallationError(Exception):

--- a/magma_access_gateway_installer/agw_installation_service_creator.py
+++ b/magma_access_gateway_installer/agw_installation_service_creator.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import os
+
+logger = logging.getLogger("magma_access_gateway_installer")
+
+
+class AGWInstallerInstallationServiceCreator:
+
+    AGW_INSTALLATION_SERVICE_FILE_PATH = "/lib/systemd/system/agw_installation.service"
+    AGW_INSTALLATION_SERVICE_LINK_PATH = (
+        "/etc/systemd/system/multi-user.target.wants/agw_installation.service"
+    )
+
+    def create_magma_agw_installation_service(self):
+        """Creates Magma AGW installation service which will be used to resume AGW installation
+        process after system reboot which is triggered by the pre-installation part.
+        """
+        logger.info("Creating Magma AGW installation service...")
+        magma_installation_service_configuration = """[Unit]
+Description=AGW Installation
+After=network-online.target
+Wants=network-online.target
+[Service]
+Environment=MAGMA_VERSION=1.6.0
+Type=oneshot
+ExecStart=/snap/magma-access-gateway/current/bin/python3 -c "from magma_access_gateway_installer.agw_installer import AGWInstaller; AGWInstaller().install()"
+SyslogIdentifier=magma_access_gateway_installer
+TimeoutStartSec=3800
+TimeoutSec=3600
+User=root
+Group=root
+[Install]
+WantedBy=multi-user.target
+"""  # noqa: E501
+        with open(self.AGW_INSTALLATION_SERVICE_FILE_PATH, "w") as installation_service:
+            installation_service.write(magma_installation_service_configuration)
+        os.chmod(self.AGW_INSTALLATION_SERVICE_FILE_PATH, 0o644)
+
+    def create_magma_agw_installation_service_link(self):
+        logger.info("Creating Magma AGW installation service link...")
+        try:
+            os.symlink(
+                self.AGW_INSTALLATION_SERVICE_FILE_PATH, self.AGW_INSTALLATION_SERVICE_LINK_PATH
+            )
+        except FileExistsError:
+            os.remove(self.AGW_INSTALLATION_SERVICE_LINK_PATH)
+            os.symlink(
+                self.AGW_INSTALLATION_SERVICE_FILE_PATH, self.AGW_INSTALLATION_SERVICE_LINK_PATH
+            )

--- a/magma_access_gateway_installer/agw_installer.py
+++ b/magma_access_gateway_installer/agw_installer.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import os
+import time
+from subprocess import check_call, check_output
+
+logger = logging.getLogger("magma_access_gateway_installer")
+
+
+class AGWInstaller:
+
+    MAGMA_AGW_RUNTIME_DEPENDENCIES = [
+        "graphviz",
+        "python-all",
+        "module-assistant",
+        "openssl",
+        "dkms",
+        "uuid-runtime",
+        "ca-certificates",
+    ]
+
+    MAGMA_INTERFACES = ["gtp_br0", "mtr0", "uplink_br0", "ipfix0", "dhcp0"]
+
+    def install(self):
+        if self._magma_agw_installed:
+            logger.info("Magma Access Gateway already installed. Exiting...")
+            return
+        else:
+            logger.info("Starting Magma AGW deployment...")
+            self.update_apt_cache()
+            self.update_ca_certificates_package()
+            self.forbid_usage_of_expired_dst_root_ca_x3_certificate()
+            self.configure_apt_for_magma_agw_deb_package_installation()
+            self.install_runtime_dependencies()
+            self.preconfigure_wireshark_suid_property()
+            self.install_magma_agw()
+            self.start_open_vswitch()
+            self.start_magma()
+            logger.info(
+                "Magma AGW deployment completed successfully!\n"
+                "System will now go down for the reboot to apply all changes.\n"
+                "After configuring Magma AGW run magma-access-gateway.post-install to verify "
+                "configuration."
+            )
+            time.sleep(5)
+            os.system("reboot")
+
+    @property
+    def _magma_agw_installed(self) -> bool:
+        """Checks whether Magma Access Gateway is already installed or not."""
+        return "magma" in check_output(["apt", "list", "--installed"]).decode()
+
+    @staticmethod
+    def update_apt_cache():
+        """Updates apt cache."""
+        logger.info("Updating apt cache...")
+        check_call(["apt", "update"])
+
+    @staticmethod
+    def update_ca_certificates_package():
+        """Updates ca-certificates package"""
+        logger.info("Updating ca-certificates package...")
+        check_call(["apt", "install", "ca-certificates"])
+
+    def forbid_usage_of_expired_dst_root_ca_x3_certificate(self):
+        """Forbids usage of mozilla/DST_Root_CA_X3.crt certificate."""
+        if not self._expired_dst_root_ca_x3_certificate_forbidden:
+            logger.info("Forbidding usage of expired mozilla/DST_Root_CA_X3.crt certificate...")
+            self._forbid_usage_of_expired_dst_root_ca_x3_certificate()
+            self._update_ca_certificates()
+
+    @property
+    def _expired_dst_root_ca_x3_certificate_forbidden(self) -> bool:
+        """Checks whether mozilla/DST_Root_CA_X3.crt is forbidden or not."""
+        with open("/etc/ca-certificates.conf", "r") as ca_certificates_file:
+            ca_certificates_file_content = ca_certificates_file.readlines()
+        for line in ca_certificates_file_content:
+            if line.startswith("!mozilla/DST_Root_CA_X3.crt"):
+                return True
+        return False
+
+    @staticmethod
+    def _forbid_usage_of_expired_dst_root_ca_x3_certificate():
+        """Comments out mozilla/DST_Root_CA_X3.crt certificate in /etc/ca-certificates.conf."""
+        with open("/etc/ca-certificates.conf", "r") as ca_certificates_file:
+            original_ca_certificates_file_content = ca_certificates_file.readlines()
+        updated_ca_certificates_file_content = [
+            line.replace(line, "!mozilla/DST_Root_CA_X3.crt\n")
+            if line.startswith("mozilla/DST_Root_CA_X3.crt")
+            else line
+            for line in original_ca_certificates_file_content
+        ]
+
+        with open("/etc/ca-certificates.conf", "w") as updated_ca_certificates_file:
+            updated_ca_certificates_file.writelines(updated_ca_certificates_file_content)
+
+    @staticmethod
+    def _update_ca_certificates():
+        """Updates ca-certificates."""
+        logger.info("Updating ca-certificates...")
+        check_call(["update-ca-certificates"])
+
+    def configure_apt_for_magma_agw_deb_package_installation(self):
+        """Prepares apt repository for Magma AGW installation."""
+        if not self._magma_apt_repository_configured:
+            self._configure_apt_for_magma_agw_deb_package_installation()
+            self.update_apt_cache()
+
+    @property
+    def _magma_apt_repository_configured(self) -> bool:
+        """Checks whether Magma custom apt repository has already been configured."""
+        return os.path.exists("/etc/apt/sources.list.d/magma.list")
+
+    def _configure_apt_for_magma_agw_deb_package_installation(self):
+        """Configures apt (repository and keys) to allow Magma AGW deb package installation."""
+        self._configure_private_apt_repository_to_install_magma_agw_from()
+        self._add_unvalidated_apt_signing_key()
+
+    @staticmethod
+    def _configure_private_apt_repository_to_install_magma_agw_from():
+        """Creates an apt repository configuration to allow Magma AGW deb package installation."""
+        logger.info("Configuring private apt repository for install Magma AGW from...")
+        with open("/etc/apt/sources.list.d/magma.list", "w") as magma_private_apt_repo:
+            magma_private_apt_repo.write(
+                "deb https://artifactory.magmacore.org/artifactory/debian focal-1.6.1 main"
+            )
+
+    def _add_unvalidated_apt_signing_key(self):
+        """Adds unvalidated apt signing key."""
+        logger.info("Adding unvalidated apt signing key...")
+        check_call(
+            [
+                "apt-key",
+                "adv",
+                "--fetch-keys",
+                "https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public",
+            ]
+        )
+        self._ignore_magma_apt_repositorys_ssl_cert()
+
+    @staticmethod
+    def _ignore_magma_apt_repositorys_ssl_cert():
+        """Ignores Magma apt repository's SSL certificate."""
+        logger.info("Ignoring Magma apt repository's SSL certificate...")
+        ignore_cert = """Acquire::https::artifactory.magmacore.org/artifactory/debian {
+Verify-Peer "false";
+Verify-Host "false";
+};
+"""
+        with open("/etc/apt/apt.conf.d/99insecurehttpsrepo", "w") as insecured_repo_host:
+            insecured_repo_host.write(ignore_cert)
+
+    def install_runtime_dependencies(self):
+        """Installs Magma AGW's runtime dependencies using apt."""
+        logger.info("Installing Magma AGW's runtime dependencies...")
+        for required_package in self.MAGMA_AGW_RUNTIME_DEPENDENCIES:
+            self._install_apt_package(required_package)
+
+    @staticmethod
+    def preconfigure_wireshark_suid_property():
+        """Prevents Wireshark popup while installing Magma AGW."""
+        configure_debconf_entry_command = 'echo "wireshark-common wireshark-common/install-setuid boolean true" | debconf-set-selections'  # noqa: E501
+        check_call(configure_debconf_entry_command, shell=True)
+
+    def install_magma_agw(self):
+        """Installs Magma AGW's deb packages from the private apt repository."""
+        logger.info("Installing Magma Access Gateway...")
+        dpkg_options = ["force-overwrite", "force-confold", "force-confdef"]
+        self._install_apt_package("magma", dpkg_options)
+
+    def start_open_vswitch(self):
+        """Start openvswitch-switch service."""
+        self._start_service("openvswitch-switch")
+
+    def start_magma(self):
+        """Starts Magma AGW."""
+        self._stop_service("magma@*")
+        self._bring_up_magma_interfaces()
+        self._start_service("magma@magma")
+
+    def _bring_up_magma_interfaces(self):
+        """Brings up interfaces created by Magma AGW."""
+        for interface in self.MAGMA_INTERFACES:
+            logger.info(f"Bringing up {interface} interface...")
+            self._bring_up_interface(interface)
+
+    @staticmethod
+    def _install_apt_package(package_name, dpkg_options: list = None):
+        """Installs package using apt."""
+        logger.info(f"Installing {package_name} package...")
+        apt_install_command = ["apt", "install", "-y", "--no-install-recommends", package_name]
+        if dpkg_options:
+            for option in dpkg_options:
+                apt_install_command.insert(1, f'-o "Dpkg::Options::=--{option}"')
+        try:
+            check_call(" ".join(apt_install_command), shell=True)
+        except Exception as any_exception:
+            logging.error(any_exception)
+            raise any_exception
+
+    @staticmethod
+    def _bring_up_interface(interface_name):
+        """Brings up interface using ifup command."""
+        logger.info(f"Bringing up {interface_name}...")
+        check_call(["ifup", interface_name])
+
+    @staticmethod
+    def _stop_service(service_name):
+        """Stops system service."""
+        logger.info(f"Stopping {service_name} service...")
+        check_call(["service", service_name, "stop"])
+
+    @staticmethod
+    def _start_service(service_name):
+        """Starts system service."""
+        logger.info(f"Starting {service_name} service...")
+        check_call(["service", service_name, "start"])

--- a/magma_access_gateway_installer/agw_network_configurator.py
+++ b/magma_access_gateway_installer/agw_network_configurator.py
@@ -10,11 +10,8 @@ from typing import Optional
 
 import ipcalc  # type: ignore[import]
 import yaml
-from systemd.journal import JournalHandler  # type: ignore[import]
 
-logger = logging.getLogger(__name__)
-logger.addHandler(JournalHandler())
-logger.setLevel(logging.INFO)
+logger = logging.getLogger("magma_access_gateway_installer")
 
 
 class AGWInstallerNetworkConfigurator:

--- a/magma_access_gateway_installer/agw_preinstall_checks.py
+++ b/magma_access_gateway_installer/agw_preinstall_checks.py
@@ -6,13 +6,9 @@ import logging
 import platform
 from subprocess import check_call
 
-from systemd.journal import JournalHandler  # type: ignore[import]
-
 from .agw_installation_errors import InvalidNumberOfInterfacesError, UnsupportedOSError
 
-logger = logging.getLogger(__name__)
-logger.addHandler(JournalHandler())
-logger.setLevel(logging.INFO)
+logger = logging.getLogger("magma_access_gateway_installer")
 
 
 class AGWInstallerPreinstallChecks:

--- a/magma_access_gateway_installer/agw_service_user_creator.py
+++ b/magma_access_gateway_installer/agw_service_user_creator.py
@@ -6,11 +6,7 @@ import logging
 import pwd
 from subprocess import check_call, check_output
 
-from systemd.journal import JournalHandler  # type: ignore[import]
-
-logger = logging.getLogger(__name__)
-logger.addHandler(JournalHandler())
-logger.setLevel(logging.INFO)
+logger = logging.getLogger("magma_access_gateway_installer")
 
 
 class AGWInstallerServiceUserCreator:

--- a/tests/unit/test_agw_installation_service_creator.py
+++ b/tests/unit/test_agw_installation_service_creator.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import mock_open, patch
+
+from magma_access_gateway_installer.agw_installation_service_creator import (
+    AGWInstallerInstallationServiceCreator,
+)
+
+
+class TestAGWInstallerInstallationServiceCreator(unittest.TestCase):
+    def setUp(self) -> None:
+        self.agw_installation_service_creator = AGWInstallerInstallationServiceCreator()
+
+    @patch(
+        "magma_access_gateway_installer.agw_installation_service_creator.open",
+        new_callable=mock_open,
+    )
+    @patch("magma_access_gateway_installer.agw_installation_service_creator.os")
+    def test_given_agw_installation_process_when_create_magma_agw_installation_service_then_proper_installation_config_is_written(  # noqa: E501
+        self, _, mock_open_file
+    ):
+        expected_magma_installation_service_configuration = """[Unit]
+Description=AGW Installation
+After=network-online.target
+Wants=network-online.target
+[Service]
+Environment=MAGMA_VERSION=1.6.0
+Type=oneshot
+ExecStart=/snap/magma-access-gateway/current/bin/python3 -c "from magma_access_gateway_installer.agw_installer import AGWInstaller; AGWInstaller().install()"
+SyslogIdentifier=magma_access_gateway_installer
+TimeoutStartSec=3800
+TimeoutSec=3600
+User=root
+Group=root
+[Install]
+WantedBy=multi-user.target
+"""  # noqa: E501
+        self.agw_installation_service_creator.create_magma_agw_installation_service()
+
+        mock_open_file.assert_called_once_with(
+            self.agw_installation_service_creator.AGW_INSTALLATION_SERVICE_FILE_PATH, "w"
+        )
+        mock_open_file().write.assert_called_once_with(
+            expected_magma_installation_service_configuration
+        )
+
+    @patch("magma_access_gateway_installer.agw_installation_service_creator.os.chmod")
+    @patch(
+        "magma_access_gateway_installer.agw_installation_service_creator.open",
+        new_callable=mock_open,
+    )
+    def test_given_created_installation_service_descriptor_when_create_magma_agw_installation_service_then_installation_service_descriptor_gets_644_permissions(  # noqa: E501
+        self, _, mock_os_chmod
+    ):
+        self.agw_installation_service_creator.create_magma_agw_installation_service()
+
+        mock_os_chmod.assert_called_with(
+            self.agw_installation_service_creator.AGW_INSTALLATION_SERVICE_FILE_PATH, 0o644
+        )
+
+    @patch("magma_access_gateway_installer.agw_installation_service_creator.os.symlink")
+    def test_given_agw_installation_process_descriptor_created_when_create_magma_agw_installation_service_link_then_symlink_to_installation_service_descriptor_is_created(  # noqa: E501
+        self, mock_os_symlink
+    ):
+        self.agw_installation_service_creator.create_magma_agw_installation_service_link()
+
+        mock_os_symlink.assert_called_once_with(
+            self.agw_installation_service_creator.AGW_INSTALLATION_SERVICE_FILE_PATH,
+            self.agw_installation_service_creator.AGW_INSTALLATION_SERVICE_LINK_PATH,
+        )
+
+    @patch("magma_access_gateway_installer.agw_installation_service_creator.os.symlink")
+    @patch("magma_access_gateway_installer.agw_installation_service_creator.os.remove")
+    def test_given_agw_installation_process_descriptor_link_exists_when_create_magma_agw_installation_service_link_then_symlink_to_installation_service_descriptor_is_recreated(  # noqa: E501
+        self, mock_os_remove, mock_os_symlink
+    ):
+        mock_os_symlink.side_effect = [FileExistsError, None]
+        self.agw_installation_service_creator.create_magma_agw_installation_service_link()
+
+        mock_os_remove.assert_called_once_with(
+            self.agw_installation_service_creator.AGW_INSTALLATION_SERVICE_LINK_PATH
+        )
+        mock_os_symlink.assert_called_with(
+            self.agw_installation_service_creator.AGW_INSTALLATION_SERVICE_FILE_PATH,
+            self.agw_installation_service_creator.AGW_INSTALLATION_SERVICE_LINK_PATH,
+        )

--- a/tests/unit/test_agw_installer.py
+++ b/tests/unit/test_agw_installer.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import Mock, call, mock_open, patch
+
+from magma_access_gateway_installer.agw_installer import AGWInstaller
+
+
+class TestAGWInstallerInstallationServiceCreator(unittest.TestCase):
+
+    APT_LIST_WITH_MAGMA = b"""lua-cjson/focal,now 2.1.0+dfsg-2.1 amd64 [installed,automatic]\n
+lvm2/focal,now 2.03.07-1ubuntu1 amd64 [installed,automatic]\n
+lxd-agent-loader/focal,now 0.4 all [installed,automatic]\n
+lz4/focal-updates,focal-security,now 1.9.2-2ubuntu0.20.04.1 amd64 [installed,automatic]\n
+magma-cpp-redis/focal-1.6.1,now 4.3.1.1-2 amd64 [installed,automatic]\n
+magma-libfluid/focal-1.6.1,now 0.1.0.6-1 amd64 [installed,automatic]\n
+magma-libtacopie/focal-1.6.1,now 3.2.0.1-1 amd64 [installed,automatic]\n
+magma-sctpd/focal-1.6.1,now 1.6.1-1636529012-5d886707 amd64 [installed,automatic]\n
+magma/focal-1.6.1,now 1.6.1-1636529012-5d886707 amd64 [installed]\n
+make/focal,now 4.2.1-1.2 amd64 [installed,automatic]\n
+man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
+"""
+    ETC_CA_CERTIFICATES_CONF_WITH_DST_ROOT_CA_X3_FORBIDDEN = """mozilla/Cybertrust_Global_Root.crt
+mozilla/D-TRUST_Root_Class_3_CA_2_2009.crt
+mozilla/D-TRUST_Root_Class_3_CA_2_EV_2009.crt
+!mozilla/DST_Root_CA_X3.crt
+!mozilla/Deutsche_Telekom_Root_CA_2.crt
+mozilla/DigiCert_Assured_ID_Root_CA.crt
+mozilla/DigiCert_Assured_ID_Root_G2.crt
+"""
+    ETC_CA_CERTIFICATES_CONF_WITH_DST_ROOT_CA_X3_ALLOWED = """mozilla/Cybertrust_Global_Root.crt
+mozilla/D-TRUST_Root_Class_3_CA_2_2009.crt
+mozilla/D-TRUST_Root_Class_3_CA_2_EV_2009.crt
+mozilla/DST_Root_CA_X3.crt
+!mozilla/Deutsche_Telekom_Root_CA_2.crt
+mozilla/DigiCert_Assured_ID_Root_CA.crt
+mozilla/DigiCert_Assured_ID_Root_G2.crt
+"""
+
+    def setUp(self) -> None:
+        self.agw_installer = AGWInstaller()
+
+    @patch(
+        "magma_access_gateway_installer.agw_installer.check_output",
+        return_value=APT_LIST_WITH_MAGMA,
+    )
+    def test_given_magma_agw_installed_when_agw_installer_then_installer_exits_without_executing_any_commands(  # noqa: E501
+        self, _
+    ):
+        self.assertEqual(self.agw_installer.install(), None)
+
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    def test_given_magma_agw_not_installed_when_update_apt_cache_then_apt_update_is_called(
+        self, mock_check_call
+    ):
+        self.agw_installer.update_apt_cache()
+
+        mock_check_call.assert_called_once_with(["apt", "update"])
+
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    def test_given_magma_agw_not_installed_when_update_ca_certificates_package_then_relevant_apt_command_is_called(  # noqa: E501
+        self, mock_check_call
+    ):
+        self.agw_installer.update_ca_certificates_package()
+
+        mock_check_call.assert_called_once_with(["apt", "install", "ca-certificates"])
+
+    @patch(
+        "magma_access_gateway_installer.agw_installer.open",
+        new_callable=mock_open,
+        read_data=ETC_CA_CERTIFICATES_CONF_WITH_DST_ROOT_CA_X3_FORBIDDEN,
+    )
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    def test_given_dst_root_ca_x3_certificate_forbidden_when_forbid_usage_of_expired_dst_root_ca_x3_certificate_then_no_changes_are_done_to_etc_ca_certificates_conf(  # noqa: E501
+        self, mock_check_call, mock_open_file
+    ):
+        self.agw_installer.forbid_usage_of_expired_dst_root_ca_x3_certificate()
+
+        mock_open_file.assert_called_once_with("/etc/ca-certificates.conf", "r")
+        mock_check_call.assert_not_called()
+
+    @patch(
+        "magma_access_gateway_installer.agw_installer.open",
+        new_callable=mock_open,
+        read_data=ETC_CA_CERTIFICATES_CONF_WITH_DST_ROOT_CA_X3_ALLOWED,
+    )
+    @patch("magma_access_gateway_installer.agw_installer.check_call", Mock())
+    def test_given_dst_root_ca_x3_certificate_allowed_when_forbid_usage_of_expired_dst_root_ca_x3_certificate_then_certificate_is_marked_as_forbidden_in_etc_ca_certificates_conf(  # noqa: E501
+        self, mock_open_file
+    ):
+        expected_etc_ca_certificates_conf = [
+            "mozilla/Cybertrust_Global_Root.crt\n",
+            "mozilla/D-TRUST_Root_Class_3_CA_2_2009.crt\n",
+            "mozilla/D-TRUST_Root_Class_3_CA_2_EV_2009.crt\n",
+            "!mozilla/DST_Root_CA_X3.crt\n",
+            "!mozilla/Deutsche_Telekom_Root_CA_2.crt\n",
+            "mozilla/DigiCert_Assured_ID_Root_CA.crt\n",
+            "mozilla/DigiCert_Assured_ID_Root_G2.crt\n",
+        ]
+
+        self.agw_installer.forbid_usage_of_expired_dst_root_ca_x3_certificate()
+
+        mock_open_file().writelines.assert_called_once_with(expected_etc_ca_certificates_conf)
+
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    @patch(
+        "magma_access_gateway_installer.agw_installer.open",
+        new_callable=mock_open,
+        read_data=ETC_CA_CERTIFICATES_CONF_WITH_DST_ROOT_CA_X3_ALLOWED,
+    )
+    def test_given_dst_root_ca_x3_certificate_allowed_when_forbid_usage_of_expired_dst_root_ca_x3_certificate_then_ca_certificates_are_updated(  # noqa: E501
+        self, _, mock_check_call
+    ):
+        self.agw_installer.forbid_usage_of_expired_dst_root_ca_x3_certificate()
+
+        mock_check_call.assert_called_once_with(["update-ca-certificates"])
+
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    @patch("magma_access_gateway_installer.agw_installer.open")
+    @patch("magma_access_gateway_installer.agw_installer.os.path.exists", return_value=True)
+    def test_given_magma_apt_repo_configured_when_configure_apt_for_magma_agw_deb_package_installation_then_new_apt_repo_is_not_created(  # noqa: E501
+        self, _, mock_open_file, mock_check_call
+    ):
+        self.agw_installer.configure_apt_for_magma_agw_deb_package_installation()
+
+        mock_open_file.assert_not_called()
+        mock_check_call.assert_not_called()
+
+    @patch("magma_access_gateway_installer.agw_installer.open", new_callable=mock_open)
+    @patch("magma_access_gateway_installer.agw_installer.check_call", Mock())
+    @patch("magma_access_gateway_installer.agw_installer.os.path.exists", return_value=False)
+    def test_given_magma_apt_repo_not_configured_when_configure_apt_for_magma_agw_deb_package_installation_then_new_apt_repo_config_file_is_created(  # noqa: E501
+        self, _, mock_open_file
+    ):
+        expected_apt_repo_config_file_content = (
+            "deb https://artifactory.magmacore.org/artifactory/debian focal-1.6.1 main"
+        )
+
+        self.agw_installer.configure_apt_for_magma_agw_deb_package_installation()
+
+        self.assertTrue(
+            call("/etc/apt/sources.list.d/magma.list", "w") in mock_open_file.mock_calls
+        )
+        self.assertTrue(
+            call(expected_apt_repo_config_file_content) in mock_open_file().write.mock_calls
+        )
+
+    @patch("magma_access_gateway_installer.agw_installer.open", new_callable=mock_open)
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    @patch("magma_access_gateway_installer.agw_installer.os.path.exists", return_value=False)
+    def test_given_magma_apt_repo_not_configured_when_configure_apt_for_magma_agw_deb_package_installation_then_unvalidated_apt_signing_key_is_added(  # noqa: E501
+        self, _, mock_check_call, mock_open_file
+    ):
+        expected_99insecurehttpsrepo_content = """Acquire::https::artifactory.magmacore.org/artifactory/debian {
+Verify-Peer "false";
+Verify-Host "false";
+};
+"""  # noqa: E501
+
+        self.agw_installer.configure_apt_for_magma_agw_deb_package_installation()
+
+        self.assertTrue(
+            call(
+                [
+                    "apt-key",
+                    "adv",
+                    "--fetch-keys",
+                    "https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public",
+                ]
+            )
+            in mock_check_call.mock_calls
+        )
+        self.assertTrue(
+            call("/etc/apt/apt.conf.d/99insecurehttpsrepo", "w") in mock_open_file.mock_calls
+        )
+        self.assertTrue(
+            call(expected_99insecurehttpsrepo_content) in mock_open_file().write.mock_calls
+        )
+
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    @patch("magma_access_gateway_installer.agw_installer.open", new_callable=mock_open)
+    @patch("magma_access_gateway_installer.agw_installer.os.path.exists", return_value=False)
+    def test_given_magma_apt_repo_not_configured_when_configure_apt_for_magma_agw_deb_package_installation_then_apt_cache_is_updated(  # noqa: E501
+        self, _, __, mock_check_call
+    ):
+        self.agw_installer.configure_apt_for_magma_agw_deb_package_installation()
+
+        self.assertTrue(call(["apt", "update"]) in mock_check_call.mock_calls)
+
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    def test_given_magma_agw_not_installed_when_install_runtime_dependencies_then_apt_installs_required_packages(  # noqa: E501
+        self, mock_check_call
+    ):
+        expected_apt_calls = [
+            call(f"apt install -y --no-install-recommends {package_name}", shell=True)
+            for package_name in self.agw_installer.MAGMA_AGW_RUNTIME_DEPENDENCIES
+        ]
+
+        self.agw_installer.install_runtime_dependencies()
+
+        mock_check_call.assert_has_calls(expected_apt_calls)
+
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    def test_given_magma_agw_not_installed_when_preconfigure_wireshark_suid_property_then_correct_configuration_is_sent_to_debconf_database(  # noqa: E501
+        self, mock_check_call
+    ):
+        self.agw_installer.preconfigure_wireshark_suid_property()
+
+        mock_check_call.assert_called_once_with(
+            'echo "wireshark-common wireshark-common/install-setuid boolean true" | debconf-set-selections',  # noqa: E501
+            shell=True,
+        )
+
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    def test_given_magma_agw_not_installed_when_install_magma_agw_then_correct_apt_command_is_called(  # noqa: E501
+        self, mock_check_call
+    ):
+        self.agw_installer.install_magma_agw()
+
+        mock_check_call.assert_called_once_with(
+            'apt -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" '
+            '-o "Dpkg::Options::=--force-overwrite" install -y --no-install-recommends magma',
+            shell=True,
+        )
+
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    def test_given_magma_installation_process_when_start_open_vswitch_then_correct_service_is_started(  # noqa: E501
+        self, mock_check_call
+    ):
+        self.agw_installer.start_open_vswitch()
+
+        mock_check_call.assert_called_once_with(["service", "openvswitch-switch", "start"])
+
+    @patch("magma_access_gateway_installer.agw_installer.check_call")
+    def test_given_magma_installation_process_when_start_magma_then_magma_services_are_stopped_interfaces_are_brought_up_and_magma_services_are_started(  # noqa: E501
+        self, mock_check_call
+    ):
+        expected_calls = [call(["service", "magma@*", "stop"])]
+        expected_calls.extend(
+            [
+                call(["ifup", magma_interface])
+                for magma_interface in self.agw_installer.MAGMA_INTERFACES
+            ]
+        )
+        expected_calls.append(call(["service", "magma@magma", "start"]))
+
+        self.agw_installer.start_magma()
+
+        mock_check_call.assert_has_calls(expected_calls)
+
+    @patch("magma_access_gateway_installer.agw_installer.os.system")
+    @patch("magma_access_gateway_installer.agw_installer.check_call", Mock())
+    @patch("magma_access_gateway_installer.agw_installer.open", mock_open())
+    def test_given_magma_not_installed_when_install_then_system_goes_for_reboot_once_installation_is_done(  # noqa: E501
+        self, mock_os_system
+    ):
+        self.agw_installer.install()
+
+        mock_os_system.assert_called_once_with("reboot")


### PR DESCRIPTION
This PR implements last part of Magma AGW deployment - the actual deb package installation.
Installation process is started via **agw_installation** service.
Essentially, installation process consists of:

- updating certificates
- installing runtime dependencies
- configuring Magma apt repository 
- installing Magma AGW from Magma apt repository
- starting Magma AGW services and interfaces

