### PR TITLE
Telco 123 agw snap agw post install checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Magma Access Gateway can be configured by executing:<br>
 For more details about Magma Access Gateway configuration, visit 
 [Magma documentation](https://docs.magmacore.org/docs/next/lte/deploy_config_agw).
 
+**Magma Access Gateway post-installation checks**
+
+Once Magma Access Gateway is installed and configured, post-installation checks can be run to 
+make sure everything has been configured correctly.<br>
+Post-installation checks can be executed by issuing:<br>
+`magma-access-gateway.post-install`
+
 ## Contributing
 
 Please see `CONTRIBUTING.md` for developer guidance.

--- a/magma_access_gateway_post_install/__init__.py
+++ b/magma_access_gateway_post_install/__init__.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+""" The Access Gateway (AGW) provides network services and policy enforcement. In an LTE network,
+  the AGW implements an evolved packet core (EPC), and a combination of an AAA and a PGW. It works
+  with existing, unmodified commercial radio hardware.
+  For detailed description visit https://docs.magmacore.org/docs/next/lte/architecture_overview.
+"""
+
+import logging
+import sys
+from argparse import ArgumentParser
+
+from .agw_post_install import AGWPostInstallChecks
+from systemd.journal import JournalHandler  # type: ignore[import]
+
+logger = logging.getLogger(__name__)
+handler = JournalHandler()
+handler.setFormatter(logging.Formatter("Magma AGW Post-Install: %(message)s"))
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+
+def main():
+    args = cli_arguments_parser(sys.argv[1:])
+
+    agw_post_install_checks = AGWPostInstallChecks(args.root_ca_path)
+
+    logger.info("Starting Magma AGW post-installation checks...")
+    agw_post_install_checks.prepare_system_for_post_install_checks()
+    agw_post_install_checks.check_whether_required_interfaces_are_configured()
+    agw_post_install_checks.check_eth0_internet_connectivity()
+    agw_post_install_checks.start_magma_service()
+    agw_post_install_checks.check_whether_required_services_are_running()
+    agw_post_install_checks.check_whether_required_packages_are_installed()
+    agw_post_install_checks.check_whether_root_certificate_exists()
+    agw_post_install_checks.check_control_proxy()
+    agw_post_install_checks.check_cloud_check_in()
+    logger.info("Magma AGW post-installation checks finished successfully.")
+
+
+def cli_arguments_parser(cli_arguments):
+    cli_options = ArgumentParser()
+    cli_options.add_argument(
+        "--root-ca-pem-path",
+        dest="root_ca_path",
+        required=True,
+        help="Path to Root CA PEM used during Orc8r deployment. Example: /home/magma/rootCA.pem",
+    )
+    return cli_options.parse_args(cli_arguments)

--- a/magma_access_gateway_post_install/__init__.py
+++ b/magma_access_gateway_post_install/__init__.py
@@ -29,10 +29,8 @@ def main():
     agw_post_install_checks = AGWPostInstallChecks(args.root_ca_path)
 
     logger.info("Starting Magma AGW post-installation checks...")
-    agw_post_install_checks.prepare_system_for_post_install_checks()
     agw_post_install_checks.check_whether_required_interfaces_are_configured()
     agw_post_install_checks.check_eth0_internet_connectivity()
-    agw_post_install_checks.start_magma_service()
     agw_post_install_checks.check_whether_required_services_are_running()
     agw_post_install_checks.check_whether_required_packages_are_installed()
     agw_post_install_checks.check_whether_root_certificate_exists()

--- a/magma_access_gateway_post_install/__init__.py
+++ b/magma_access_gateway_post_install/__init__.py
@@ -12,8 +12,9 @@ import logging
 import sys
 from argparse import ArgumentParser
 
-from .agw_post_install import AGWPostInstallChecks
 from systemd.journal import JournalHandler  # type: ignore[import]
+
+from .agw_post_install import AGWPostInstallChecks
 
 logger = logging.getLogger(__name__)
 handler = JournalHandler()

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -2,14 +2,14 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import os
 import logging
+import os
 import time
-from subprocess import call, check_call, DEVNULL
+from subprocess import DEVNULL, call, check_call
 
 import yaml
-from ping3 import ping
-from systemd import journal
+from ping3 import ping  # type: ignore[import]
+from systemd import journal  # type: ignore[import]
 
 logger = logging.getLogger("magma_access_gateway_post_install")
 
@@ -77,10 +77,10 @@ class AGWPostInstallChecks:
         """
         logger.info("Checking network interfaces configuration...")
         faulty_interfaces = [
-            interface for interface in self.MAGMA_AGW_INTERFACES
-            if not os.path.exists(
-                os.path.join("/sys/class/net", interface, "operstate")
-            ) or "down" in self._get_interface_state(interface)
+            interface
+            for interface in self.MAGMA_AGW_INTERFACES
+            if not os.path.exists(os.path.join("/sys/class/net", interface, "operstate"))
+            or "down" in self._get_interface_state(interface)  # noqa: W503
         ]
         if faulty_interfaces:
             raise AGWConfigurationError(
@@ -114,7 +114,8 @@ class AGWPostInstallChecks:
         """
         logger.info("Checking whether required services are running...")
         services_down = [
-            service for service in self.MAGMA_AGW_SERVICES + self.NON_MAGMA_SERVICES
+            service
+            for service in self.MAGMA_AGW_SERVICES + self.NON_MAGMA_SERVICES
             if self._wait_for_service(service)
         ]
         if services_down:
@@ -128,7 +129,8 @@ class AGWPostInstallChecks:
         """
         logger.info("Checking whether required packages are installed...")
         missing_packages = [
-            package for package in self.REQUIRED_PACKAGES
+            package
+            for package in self.REQUIRED_PACKAGES
             if not self._package_is_installed(package)
         ]
         if missing_packages:
@@ -158,14 +160,17 @@ class AGWPostInstallChecks:
         journal_reader.log_level(journal.LOG_INFO)
         journal_reader.this_boot()
         journal_reader.add_match(SYSLOG_IDENTIFIER="magmad")
-        if not any(
+        if not (
+            any(
                 entry["MESSAGE"]
                 for entry in journal_reader
                 if self.GOT_CLOUD_HEARTBEAT_MSG in entry["MESSAGE"]
-        ) and any(
-            entry["MESSAGE"]
-            for entry in journal_reader
-            if self.CLOUD_CHECKIN_SUCCESSFUL_MSG in entry["MESSAGE"]
+            )
+            or any(  # noqa: W503
+                entry["MESSAGE"]
+                for entry in journal_reader
+                if self.CLOUD_CHECKIN_SUCCESSFUL_MSG in entry["MESSAGE"]
+            )
         ):
             raise AGWCloudCheckinError()
 
@@ -322,12 +327,12 @@ class AGWControlProxyConfigurationError(Exception):
 class AGWCloudCheckinError(Exception):
     def __init__(self):
         logger.error(
-            f"Cloud checkin failed!"
+            "Cloud checkin failed!"
             "Please follow Access Gateway Configuration section of Magma AGW documentation "
             "(https://docs.magmacore.org/docs/next/lte/deploy_config_agw) and retry."
         )
         super().__init__(
-            f"Cloud checkin failed!"
+            "Cloud checkin failed!"
             "Please follow Access Gateway Configuration section of Magma AGW documentation "
             "(https://docs.magmacore.org/docs/next/lte/deploy_config_agw) and retry."
         )

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -101,12 +101,11 @@ class AGWPostInstallChecks:
             AGWServiceNotRunningError: if any of required services is not running
         """
         logger.info("Checking whether required services are running...")
-        services_down = [
+       if services_down := [
             service
             for service in self.MAGMA_AGW_SERVICES + self.NON_MAGMA_SERVICES
             if self._wait_for_service(service)
-        ]
-        if services_down:
+        ]:
             raise AGWServicesNotRunningError(services_down)
 
     def check_whether_required_packages_are_installed(self):

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -173,6 +173,8 @@ class AGWPostInstallChecks:
             )
         ):
             raise AGWCloudCheckinError()
+        else:
+            return True
 
     @staticmethod
     def _get_interface_state(interface_name):

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import os
+import logging
+import time
+from subprocess import call, check_call, DEVNULL
+
+import yaml
+from ping3 import ping
+from systemd import journal
+
+logger = logging.getLogger("magma_access_gateway_post_install")
+
+
+class AGWPostInstallChecks:
+
+    MAGMA_AGW_INTERFACES = ["eth0", "eth1", "gtp_br0", "uplink_br0"]
+    MAGMA_AGW_SERVICES = [
+        "magma@control_proxy",
+        "magma@directoryd",
+        "magma@dnsd",
+        "magma@enodebd",
+        "magma@magmad",
+        "magma@mme",
+        "magma@mobilityd",
+        "magma@pipelined",
+        "magma@policydb",
+        "magma@redis",
+        "magma@sessiond",
+        "magma@state",
+        "magma@subscriberdb",
+    ]
+    NON_MAGMA_SERVICES = ["sctpd"]
+    REQUIRED_PACKAGES = [
+        "magma",
+        "magma-cpp-redis",
+        "magma-libfluid",
+        "libopenvswitch",
+        "openvswitch-datapath-dkms",
+        "openvswitch-common",
+        "openvswitch-switch",
+    ]
+    REQUIRED_CONTROL_PROXY_KEYS = [
+        "cloud_address",
+        "cloud_port",
+        "bootstrap_address",
+        "bootstrap_port",
+        "rootca_cert",
+        "fluentd_address",
+        "fluentd_port",
+        "sentry_url_python",
+    ]
+    GOT_CLOUD_HEARTBEAT_MSG = "[SyncRPC] Got heartBeat from cloud"
+    CLOUD_CHECKIN_SUCCESSFUL_MSG = "Checkin Successful! Successfully sent states to the cloud!"
+    TIMEOUT_WAITING_FOR_SERVICE = 60
+    WAIT_FOR_SERVICE_INTERVAL = 10
+
+    def __init__(self, root_ca_pem_path: str):
+        self.root_ca_pem_path = root_ca_pem_path
+
+    def prepare_system_for_post_install_checks(self):
+        """Makes sure system is in the right state for performing post-install checks."""
+        self._stop_service("magma@*")
+        self._bring_down_interface("gtp_br0")
+        self._bring_down_interface("uplink_br0")
+        self._restart_service("openvswitch-switch")
+        self._bring_up_interface("gtp_br0")
+        self._bring_up_interface("uplink_br0")
+
+    def check_whether_required_interfaces_are_configured(self):
+        """Checks whether Magma AGW interfaces are configured or not.
+
+        :raises:
+            AGWConfigurationError: if any of specified interfaces hasn't been configured
+        """
+        logger.info("Checking network interfaces configuration...")
+        faulty_interfaces = [
+            interface for interface in self.MAGMA_AGW_INTERFACES
+            if not os.path.exists(
+                os.path.join("/sys/class/net", interface, "operstate")
+            ) or "down" in self._get_interface_state(interface)
+        ]
+        if faulty_interfaces:
+            raise AGWConfigurationError(
+                f'Following interfaces are not configured: {" ".join(faulty_interfaces)}\n'
+                f"Check each interface's setup under /etc/network/interfaces.d/."
+            )
+
+    @staticmethod
+    def check_eth0_internet_connectivity():
+        """Checks eth0's network connectivity by pinging DNS.
+
+        :raises:
+            AGWConfigurationError: if eth0 fails to connect to the internet
+        """
+        logger.info("Checking eth0's internet connectivity...")
+        if not bool(ping("8.8.8.8")):
+            raise AGWConfigurationError(
+                "eth0 is not connected to the internet!\n"
+                "Make sure the hardware has been properly plugged in (eth0 to internet)."
+            )
+
+    def start_magma_service(self):
+        """Starts magma service."""
+        self._start_service("magma@magmad")
+
+    def check_whether_required_services_are_running(self):
+        """Checks whether all services required by Magma AGW are running.
+
+        :raises:
+            AGWServiceNotRunningError: if any of required services is not running
+        """
+        logger.info("Checking whether required services are running...")
+        services_down = [
+            service for service in self.MAGMA_AGW_SERVICES + self.NON_MAGMA_SERVICES
+            if self._wait_for_service(service)
+        ]
+        if services_down:
+            raise AGWServicesNotRunningError(services_down)
+
+    def check_whether_required_packages_are_installed(self):
+        """Checks whether all packages required by Magma AGW are installed.
+
+        :raises:
+            AGWPackageMissingError: if any Magma AGW packages are missing
+        """
+        logger.info("Checking whether required packages are installed...")
+        missing_packages = [
+            package for package in self.REQUIRED_PACKAGES
+            if not self._package_is_installed(package)
+        ]
+        if missing_packages:
+            raise AGWPackagesMissingError(missing_packages)
+
+    def check_whether_root_certificate_exists(self):
+        """Checks whether rootCA.pem certificate exists under /var/opt/magma/tmp/certs/.
+
+        :raises:
+            AGWRootCertificateMissingError: if the certificate is missing
+        """
+        logger.info("Checking whether Root Certificate exists...")
+        if not os.path.exists(os.path.join("/var/opt/magma/tmp/certs", self.root_ca_pem_path)):
+            raise AGWRootCertificateMissingError()
+
+    def check_control_proxy(self):
+        """Checks whether Control Proxy is configured."""
+        logger.info("Checking Control Proxy configuration...")
+        if not self._control_proxy_config_exists:
+            raise AGWControlProxyConfigFileMissingError()
+        self._check_control_proxy_configuration()
+
+    def check_cloud_check_in(self):
+        """Checks whether Access Gateway successfully checked into cloud."""
+        logger.info("Checking AGW cloud checkin status...")
+        journal_reader = journal.Reader()
+        journal_reader.log_level(journal.LOG_INFO)
+        journal_reader.this_boot()
+        journal_reader.add_match(SYSLOG_IDENTIFIER="magmad")
+        if not any(
+                entry["MESSAGE"]
+                for entry in journal_reader
+                if self.GOT_CLOUD_HEARTBEAT_MSG in entry["MESSAGE"]
+        ) and any(
+            entry["MESSAGE"]
+            for entry in journal_reader
+            if self.CLOUD_CHECKIN_SUCCESSFUL_MSG in entry["MESSAGE"]
+        ):
+            raise AGWCloudCheckinError()
+
+    @staticmethod
+    def _get_interface_state(interface_name):
+        """Gets interface state from operstate file."""
+        with open(os.path.join("/sys/class/net", interface_name, "operstate"), "r") as if_conf:
+            return if_conf.read().strip()
+
+    @property
+    def _control_proxy_config_exists(self) -> bool:
+        """Checks whether Control Proxy config file exists."""
+        return os.path.exists("/var/opt/magma/configs/control_proxy.yml")
+
+    def _check_control_proxy_configuration(self):
+        """Checks whether Control Proxy config file contains all required keys.
+
+        :raises:
+            AGWControlProxyConfigurationError: if any of the required configuration parameters
+            is missing
+        """
+        with open("/var/opt/magma/configs/control_proxy.yml", "r") as control_proxy_file:
+            control_proxy_file_content = yaml.safe_load(control_proxy_file)
+        missing_config_keys = list(
+            set(self.REQUIRED_CONTROL_PROXY_KEYS) - set(control_proxy_file_content.keys())
+        )
+        if missing_config_keys:
+            raise AGWControlProxyConfigurationError(missing_config_keys)
+
+    def _wait_for_service(self, service_name):
+        """Waits for specified service to become active. If it doesn't happen within 60 seconds,
+        service name is returned.
+        """
+        now = time.time()
+        while time.time() < now + self.TIMEOUT_WAITING_FOR_SERVICE:
+            if self._service_is_running(service_name):
+                return
+            time.sleep(self.WAIT_FOR_SERVICE_INTERVAL)
+        return service_name
+
+    @staticmethod
+    def _service_is_running(service_name) -> bool:
+        """Checks whether specified systemd service is running."""
+        return call(["systemctl", "is-active", "--quiet", service_name]) == 0
+
+    @staticmethod
+    def _package_is_installed(package_name) -> bool:
+        """Checks whether specified system package is installed."""
+        return call(["dpkg-query", "-W", "-f='${Status}'", package_name], stdout=DEVNULL) == 0
+
+    @staticmethod
+    def _bring_up_interface(interface_name):
+        """Brings up interface using ifup command."""
+        logger.info(f"Bringing up {interface_name}...")
+        check_call(["ifup", interface_name])
+
+    @staticmethod
+    def _bring_down_interface(interface_name):
+        """Brings down interface using ifup command."""
+        logger.info(f"Bringing down {interface_name}...")
+        check_call(["ifdown", interface_name])
+
+    @staticmethod
+    def _start_service(service_name):
+        """Starts system service."""
+        logger.info(f"Starting {service_name} service...")
+        check_call(["service", service_name, "start"])
+
+    @staticmethod
+    def _stop_service(service_name):
+        """Stops system service."""
+        logger.info(f"Stopping {service_name} service...")
+        check_call(["service", service_name, "stop"])
+
+    @staticmethod
+    def _restart_service(service_name):
+        """Restarts system service."""
+        logger.info(f"Restarting {service_name} service...")
+        check_call(["service", service_name, "restart"])
+
+
+class AGWConfigurationError(Exception):
+    def __init__(self, message):
+        logger.error(message)
+        super().__init__(message)
+
+
+class AGWServicesNotRunningError(Exception):
+    def __init__(self, not_running_services: list):
+        logger.error(
+            f'Following services are not running: {" ".join(not_running_services)}\n'
+            "Please check Magma FAQ at https://docs.magmacore.org/docs/next/faq/faq_magma."
+        )
+        super().__init__(
+            f'Following services are not running: {" ".join(not_running_services)}\n'
+            "Please check Magma FAQ at https://docs.magmacore.org/docs/next/faq/faq_magma."
+        )
+
+
+class AGWPackagesMissingError(Exception):
+    def __init__(self, missing_packages: list):
+        logger.error(
+            f'Following Magma AGW packages are not installed: {" ".join(missing_packages)}\n'
+            "Please try running Magma AGW installation again."
+        )
+        super().__init__(
+            f'Following Magma AGW packages are not installed: {" ".join(missing_packages)}\n'
+            "Please try running Magma AGW installation again."
+        )
+
+
+class AGWRootCertificateMissingError(Exception):
+    def __init__(self):
+        logger.error(
+            "Root Certificate not found under /var/opt/magma/tmp/certs/.\n"
+            "Please follow Access Gateway Configuration section of Magma AGW documentation "
+            "(https://docs.magmacore.org/docs/next/lte/deploy_config_agw) and retry."
+        )
+        super().__init__(
+            "Root Certificate not found under /var/opt/magma/tmp/certs/.\n"
+            "Please follow Access Gateway Configuration section of Magma AGW documentation "
+            "(https://docs.magmacore.org/docs/next/lte/deploy_config_agw) and retry."
+        )
+
+
+class AGWControlProxyConfigFileMissingError(Exception):
+    def __init__(self):
+        logger.error(
+            "Control Proxy configuration file missing!\n"
+            "Please follow Access Gateway Configuration section of Magma AGW documentation "
+            "(https://docs.magmacore.org/docs/next/lte/deploy_config_agw) and retry."
+        )
+        super().__init__(
+            "Control Proxy configuration file missing!\n"
+            "Please follow Access Gateway Configuration section of Magma AGW documentation "
+            "(https://docs.magmacore.org/docs/next/lte/deploy_config_agw) and retry."
+        )
+
+
+class AGWControlProxyConfigurationError(Exception):
+    def __init__(self, missing_keys: list):
+        logger.error(
+            f'Following Control Proxy parameters are not configured: {" ".join(missing_keys)}\n'
+            "Please follow Access Gateway Configuration section of Magma AGW documentation "
+            "(https://docs.magmacore.org/docs/next/lte/deploy_config_agw) and retry."
+        )
+        super().__init__(
+            f'Following Control Proxy parameters are not configured: {" ".join(missing_keys)}\n'
+            "Please follow Access Gateway Configuration section of Magma AGW documentation "
+            "(https://docs.magmacore.org/docs/next/lte/deploy_config_agw) and retry."
+        )
+
+
+class AGWCloudCheckinError(Exception):
+    def __init__(self):
+        logger.error(
+            f"Cloud checkin failed!"
+            "Please follow Access Gateway Configuration section of Magma AGW documentation "
+            "(https://docs.magmacore.org/docs/next/lte/deploy_config_agw) and retry."
+        )
+        super().__init__(
+            f"Cloud checkin failed!"
+            "Please follow Access Gateway Configuration section of Magma AGW documentation "
+            "(https://docs.magmacore.org/docs/next/lte/deploy_config_agw) and retry."
+        )

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -116,12 +116,11 @@ class AGWPostInstallChecks:
             AGWPackageMissingError: if any Magma AGW packages are missing
         """
         logger.info("Checking whether required packages are installed...")
-        missing_packages = [
+        if missing_packages := [
             package
             for package in self.REQUIRED_PACKAGES
             if not self._package_is_installed(package)
-        ]
-        if missing_packages:
+        ]:
             raise AGWPackagesMissingError(missing_packages)
 
     def check_whether_root_certificate_exists(self):

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -87,7 +87,7 @@ class AGWPostInstallChecks:
             AGWConfigurationError: if eth0 fails to connect to the internet
         """
         logger.info("Checking eth0's internet connectivity...")
-        if not bool(ping("8.8.8.8")):
+        if not bool(ping(dest_addr="8.8.8.8", interface="eth0")):
             raise AGWConfigurationError(
                 "eth0 is not connected to the internet!\n"
                 "Make sure the hardware has been properly plugged in (eth0 to internet)."

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -184,10 +184,10 @@ class AGWPostInstallChecks:
         """
         with open("/var/opt/magma/configs/control_proxy.yml", "r") as control_proxy_file:
             control_proxy_file_content = yaml.safe_load(control_proxy_file)
-        missing_config_keys = list(
-            set(self.REQUIRED_CONTROL_PROXY_KEYS) - set(control_proxy_file_content.keys())
-        )
-        if missing_config_keys:
+      if missing_config_keys := list(
+            set(self.REQUIRED_CONTROL_PROXY_KEYS)
+            - set(control_proxy_file_content.keys())
+        ):
             raise AGWControlProxyConfigurationError(missing_config_keys)
 
     def _wait_for_service(self, service_name):

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -67,13 +67,14 @@ class AGWPostInstallChecks:
             AGWConfigurationError: if any of specified interfaces hasn't been configured
         """
         logger.info("Checking network interfaces configuration...")
-        faulty_interfaces = [
+       if faulty_interfaces := [
             interface
             for interface in self.MAGMA_AGW_INTERFACES
-            if not os.path.exists(os.path.join("/sys/class/net", interface, "operstate"))
+            if not os.path.exists(
+                os.path.join("/sys/class/net", interface, "operstate")
+            )
             or "down" in self._get_interface_state(interface)  # noqa: W503
-        ]
-        if faulty_interfaces:
+        ]:
             raise AGWConfigurationError(
                 f'Following interfaces are not configured: {" ".join(faulty_interfaces)}\n'
                 f"Check each interface's setup under /etc/network/interfaces.d/."

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -67,12 +67,10 @@ class AGWPostInstallChecks:
             AGWConfigurationError: if any of specified interfaces hasn't been configured
         """
         logger.info("Checking network interfaces configuration...")
-       if faulty_interfaces := [
+        if faulty_interfaces := [
             interface
             for interface in self.MAGMA_AGW_INTERFACES
-            if not os.path.exists(
-                os.path.join("/sys/class/net", interface, "operstate")
-            )
+            if not os.path.exists(os.path.join("/sys/class/net", interface, "operstate"))
             or "down" in self._get_interface_state(interface)  # noqa: W503
         ]:
             raise AGWConfigurationError(
@@ -101,7 +99,7 @@ class AGWPostInstallChecks:
             AGWServiceNotRunningError: if any of required services is not running
         """
         logger.info("Checking whether required services are running...")
-       if services_down := [
+        if services_down := [
             service
             for service in self.MAGMA_AGW_SERVICES + self.NON_MAGMA_SERVICES
             if self._wait_for_service(service)
@@ -182,9 +180,8 @@ class AGWPostInstallChecks:
         """
         with open("/var/opt/magma/configs/control_proxy.yml", "r") as control_proxy_file:
             control_proxy_file_content = yaml.safe_load(control_proxy_file)
-      if missing_config_keys := list(
-            set(self.REQUIRED_CONTROL_PROXY_KEYS)
-            - set(control_proxy_file_content.keys())
+        if missing_config_keys := list(
+            set(self.REQUIRED_CONTROL_PROXY_KEYS) - set(control_proxy_file_content.keys())
         ):
             raise AGWControlProxyConfigurationError(missing_config_keys)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cryptography
 ipcalc
 netifaces
+ping3
 six
 systemd-python
 validators

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,13 @@ setup(
     packages=[
         "magma_access_gateway_installer",
         "magma_access_gateway_configurator",
+        "magma_access_gateway_post_install",
     ],
     entry_points={
         "console_scripts": [
             "install-agw=magma_access_gateway_installer:main",
             "configure-agw=magma_access_gateway_configurator:main",
+            "agw-postinstall=magma_access_gateway_post_install:main",
         ],
     },
 )

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,8 @@ apps:
     command: bin/install-agw
   configure:
     command: bin/configure-agw
+  post-install:
+    command: bin/agw-postinstall
 
 parts:
   magma-access-gateway:

--- a/tests/unit/test_agw_post_install.py
+++ b/tests/unit/test_agw_post_install.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import MagicMock, Mock, PropertyMock, call, mock_open, patch
+
+import systemd.journal
+
+import magma_access_gateway_post_install.agw_post_install
+from magma_access_gateway_post_install.agw_post_install import (
+    AGWCloudCheckinError,
+    AGWConfigurationError,
+    AGWControlProxyConfigFileMissingError,
+    AGWControlProxyConfigurationError,
+    AGWPackagesMissingError,
+    AGWPostInstallChecks,
+    AGWRootCertificateMissingError,
+    AGWServicesNotRunningError,
+)
+
+
+class TestAGWPostInstallChecks(unittest.TestCase):
+
+    TEST_MAGMA_AGW_INTERFACES = ["iface1", "iface2", "iface3"]
+    TEST_MAGMA_AGW_SERVICES = ["magma@service1", "magma@service2", "magma@service3"]
+    TEST_NON_MAGMA_SERVICES = ["service1", "service2", "service3"]
+    TEST_TIMEOUT_WAITING_FOR_SERVICE = 1
+    TEST_WAIT_FOR_SERVICE_INTERVAL = 1
+    TEST_REQUIRED_PACKAGES = ["package1", "package2", "package3"]
+
+    def setUp(self) -> None:
+        self.agw_post_install = AGWPostInstallChecks("/test/root/ca/pem/path")
+
+    @patch("magma_access_gateway_post_install.agw_post_install.check_call")
+    def test_given_installed_magma_agw_when_prepare_system_for_post_install_checks_then_relevant_actions_on_services_and_interfaces_are_executed(  # noqa: E501
+        self, mocked_check_call
+    ):
+        expected_calls = [
+            call(["service", "magma@*", "stop"]),
+            call(["ifdown", "gtp_br0"]),
+            call(["ifdown", "uplink_br0"]),
+            call(["service", "openvswitch-switch", "restart"]),
+            call(["ifup", "gtp_br0"]),
+            call(["ifup", "uplink_br0"]),
+        ]
+
+        self.agw_post_install.prepare_system_for_post_install_checks()
+
+        mocked_check_call.assert_has_calls(expected_calls)
+
+    @patch("magma_access_gateway_post_install.agw_post_install.os.path.exists")
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.AGWPostInstallChecks.MAGMA_AGW_INTERFACES",  # noqa: E501
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.open",
+        new_callable=mock_open,
+        read_data="up",
+    )
+    def test_given_some_agw_interfaces_missing_operstate_when_check_whether_required_interfaces_are_configured_then_AGWConfigurationError_is_raised(  # noqa: E501
+        self, _, mocked_magma_interfaces, mocked_path_exists
+    ):
+        mocked_magma_interfaces.return_value = self.TEST_MAGMA_AGW_INTERFACES
+        mocked_path_exists.side_effect = [True, False, True]
+
+        with self.assertRaises(AGWConfigurationError):
+            self.agw_post_install.check_whether_required_interfaces_are_configured()
+
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.open",
+        new_callable=mock_open(),
+    )
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.os.path.exists",
+        Mock(return_value=True),
+    )
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.AGWPostInstallChecks.MAGMA_AGW_INTERFACES",  # noqa: E501
+        new_callable=PropertyMock,
+    )
+    def test_given_some_agw_interfaces_in_down_state_when_check_whether_required_interfaces_are_configured_then_AGWConfigurationError_is_raised(  # noqa: E501
+        self, mocked_agw_ifaces, mocked_open
+    ):
+        mocked_agw_ifaces.return_value = self.TEST_MAGMA_AGW_INTERFACES
+        interfaces_states = ["up", "down", "up"]
+        mocked_open.side_effect = [
+            mock_open(read_data=content).return_value for content in interfaces_states
+        ]
+
+        with self.assertRaises(AGWConfigurationError):
+            self.agw_post_install.check_whether_required_interfaces_are_configured()
+
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.ping",
+        Mock(return_value=None),
+    )
+    def test_given_no_network_connectivity_on_eth0_when_check_eth0_internet_connectivity_then_AGWConfigurationError_is_raised(  # noqa: E501
+        self,
+    ):
+        with self.assertRaises(AGWConfigurationError):
+            self.agw_post_install.check_eth0_internet_connectivity()
+
+    @patch("magma_access_gateway_post_install.agw_post_install.check_call")
+    def test_given_magma_service_not_running_when_start_magma_service_then_magma_service_is_started(  # noqa: E501
+        self, mocked_check_call
+    ):
+        self.agw_post_install.start_magma_service()
+
+        mocked_check_call.assert_called_once_with(["service", "magma@magmad", "start"])
+
+    @patch("magma_access_gateway_post_install.agw_post_install.call")
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.AGWPostInstallChecks.MAGMA_AGW_SERVICES",  # noqa: E501
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.AGWPostInstallChecks.NON_MAGMA_SERVICES",  # noqa: E501
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.AGWPostInstallChecks.TIMEOUT_WAITING_FOR_SERVICE",  # noqa: E501
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.AGWPostInstallChecks.WAIT_FOR_SERVICE_INTERVAL",  # noqa: E501
+        new_callable=PropertyMock,
+    )
+    def test_given_some_agw_services_not_running_when_check_whether_required_services_are_running_then_AGWServicesNotRunningError_is_raised(  # noqa: E501
+        self,
+        mocked_wait_for_service_interval,
+        mocked_timeout_waiting_for_service,
+        mocked_non_magma_services,
+        mocked_magma_services,
+        mocked_call,
+    ):
+        mocked_magma_services.return_value = self.TEST_MAGMA_AGW_SERVICES
+        mocked_non_magma_services.return_value = self.TEST_NON_MAGMA_SERVICES
+        mocked_timeout_waiting_for_service.return_value = self.TEST_TIMEOUT_WAITING_FOR_SERVICE
+        mocked_wait_for_service_interval.return_value = self.TEST_WAIT_FOR_SERVICE_INTERVAL
+        is_service_running_states = [False, True, True, False, False, True]
+
+        mocked_call.side_effect = is_service_running_states
+
+        with self.assertRaises(AGWServicesNotRunningError):
+            self.agw_post_install.check_whether_required_services_are_running()
+
+    @patch("magma_access_gateway_post_install.agw_post_install.call")
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.AGWPostInstallChecks.REQUIRED_PACKAGES",  # noqa: E501
+        new_callable=PropertyMock,
+    )
+    def test_given_not_all_required_magma_packages_are_installed_when_check_whether_required_packages_are_installed_then_AGWPackagesMissingError_is_raised(  # noqa: E501
+        self, mocked_required_packages, mocked_call
+    ):
+        mocked_required_packages.return_value = self.TEST_REQUIRED_PACKAGES
+        package_is_installed_statuses = [True, False, True]
+
+        mocked_call.side_effect = package_is_installed_statuses
+
+        with self.assertRaises(AGWPackagesMissingError):
+            self.agw_post_install.check_whether_required_packages_are_installed()
+
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.os.path.exists",
+        Mock(return_value=False),
+    )
+    def test_given_invalid_root_ca_pem_path_when_check_whether_root_certificate_exists_then_AGWRootCertificateMissingError_is_raised(  # noqa: E501
+        self,
+    ):
+        with self.assertRaises(AGWRootCertificateMissingError):
+            self.agw_post_install.check_whether_root_certificate_exists()
+
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.os.path.exists",
+        Mock(return_value=False),
+    )
+    def test_given_control_proxy_config_file_missing_when_check_control_proxy_then_AGWControlProxyConfigFileMissingError_is_raised(  # noqa: E501
+        self,
+    ):
+        with self.assertRaises(AGWControlProxyConfigFileMissingError):
+            self.agw_post_install.check_control_proxy()
+
+    @patch("magma_access_gateway_installer.agw_network_configurator.yaml.safe_load")
+    @patch("magma_access_gateway_post_install.agw_post_install.open", new_callable=mock_open())
+    @patch(
+        "magma_access_gateway_post_install.agw_post_install.os.path.exists",
+        Mock(return_value=True),
+    )
+    def test_given_control_proxy_config_file_is_missing_required_keys_when_check_control_proxy_then_AGWControlProxyConfigurationError_is_raised(  # noqa: E501
+        self, _, mocked_yaml_safe_load
+    ):
+        invalid_control_proxy_config_file = {
+            "cloud_address": "controller.example.com",
+            "cloud_port": 443,
+            "bootstrap_address": "bootstrapper-controller.example.com",
+            "fluentd_address": "fluentd.example.com",
+            "fluentd_port": 24224,
+            "rootca_cert": "/test/root/ca/pem/path",
+        }
+        mocked_yaml_safe_load.return_value = invalid_control_proxy_config_file
+
+        with self.assertRaises(AGWControlProxyConfigurationError):
+            self.agw_post_install.check_control_proxy()
+
+    # def test_given_journal_not_containing_cloud_checkin_logs_when_check_cloud_check_in_then_AGWCloudCheckinError_is_raised(  # noqa: E501
+    #     self,
+    # ):
+    #     with self.assertRaises(AGWCloudCheckinError):
+    #         self.agw_post_install.check_cloud_check_in()

--- a/tests/unit/test_agw_post_install.py
+++ b/tests/unit/test_agw_post_install.py
@@ -3,7 +3,7 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest.mock import Mock, PropertyMock, call, mock_open, patch
+from unittest.mock import Mock, PropertyMock, mock_open, patch
 
 from magma_access_gateway_post_install.agw_post_install import (
     AGWCloudCheckinError,
@@ -28,23 +28,6 @@ class TestAGWPostInstallChecks(unittest.TestCase):
 
     def setUp(self) -> None:
         self.agw_post_install = AGWPostInstallChecks("/test/root/ca/pem/path")
-
-    @patch("magma_access_gateway_post_install.agw_post_install.check_call")
-    def test_given_installed_magma_agw_when_prepare_system_for_post_install_checks_then_relevant_actions_on_services_and_interfaces_are_executed(  # noqa: E501
-        self, mocked_check_call
-    ):
-        expected_calls = [
-            call(["service", "magma@*", "stop"]),
-            call(["ifdown", "gtp_br0"]),
-            call(["ifdown", "uplink_br0"]),
-            call(["service", "openvswitch-switch", "restart"]),
-            call(["ifup", "gtp_br0"]),
-            call(["ifup", "uplink_br0"]),
-        ]
-
-        self.agw_post_install.prepare_system_for_post_install_checks()
-
-        mocked_check_call.assert_has_calls(expected_calls)
 
     @patch("magma_access_gateway_post_install.agw_post_install.os.path.exists")
     @patch(
@@ -98,14 +81,6 @@ class TestAGWPostInstallChecks(unittest.TestCase):
     ):
         with self.assertRaises(AGWConfigurationError):
             self.agw_post_install.check_eth0_internet_connectivity()
-
-    @patch("magma_access_gateway_post_install.agw_post_install.check_call")
-    def test_given_magma_service_not_running_when_start_magma_service_then_magma_service_is_started(  # noqa: E501
-        self, mocked_check_call
-    ):
-        self.agw_post_install.start_magma_service()
-
-        mocked_check_call.assert_called_once_with(["service", "magma@magmad", "start"])
 
     @patch("magma_access_gateway_post_install.agw_post_install.call")
     @patch(

--- a/tests/unit/test_agw_post_install.py
+++ b/tests/unit/test_agw_post_install.py
@@ -3,11 +3,8 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest.mock import MagicMock, Mock, PropertyMock, call, mock_open, patch
+from unittest.mock import Mock, PropertyMock, call, mock_open, patch
 
-import systemd.journal
-
-import magma_access_gateway_post_install.agw_post_install
 from magma_access_gateway_post_install.agw_post_install import (
     AGWCloudCheckinError,
     AGWConfigurationError,
@@ -59,7 +56,7 @@ class TestAGWPostInstallChecks(unittest.TestCase):
         new_callable=mock_open,
         read_data="up",
     )
-    def test_given_some_agw_interfaces_missing_operstate_when_check_whether_required_interfaces_are_configured_then_AGWConfigurationError_is_raised(  # noqa: E501
+    def test_given_some_agw_interfaces_missing_operstate_when_check_whether_required_interfaces_are_configured_then_agwconfigurationerror_is_raised(  # noqa: E501
         self, _, mocked_magma_interfaces, mocked_path_exists
     ):
         mocked_magma_interfaces.return_value = self.TEST_MAGMA_AGW_INTERFACES
@@ -80,7 +77,7 @@ class TestAGWPostInstallChecks(unittest.TestCase):
         "magma_access_gateway_post_install.agw_post_install.AGWPostInstallChecks.MAGMA_AGW_INTERFACES",  # noqa: E501
         new_callable=PropertyMock,
     )
-    def test_given_some_agw_interfaces_in_down_state_when_check_whether_required_interfaces_are_configured_then_AGWConfigurationError_is_raised(  # noqa: E501
+    def test_given_some_agw_interfaces_in_down_state_when_check_whether_required_interfaces_are_configured_then_agwconfigurationerror_is_raised(  # noqa: E501
         self, mocked_agw_ifaces, mocked_open
     ):
         mocked_agw_ifaces.return_value = self.TEST_MAGMA_AGW_INTERFACES
@@ -96,7 +93,7 @@ class TestAGWPostInstallChecks(unittest.TestCase):
         "magma_access_gateway_post_install.agw_post_install.ping",
         Mock(return_value=None),
     )
-    def test_given_no_network_connectivity_on_eth0_when_check_eth0_internet_connectivity_then_AGWConfigurationError_is_raised(  # noqa: E501
+    def test_given_no_network_connectivity_on_eth0_when_check_eth0_internet_connectivity_then_agwconfigurationerror_is_raised(  # noqa: E501
         self,
     ):
         with self.assertRaises(AGWConfigurationError):
@@ -127,7 +124,7 @@ class TestAGWPostInstallChecks(unittest.TestCase):
         "magma_access_gateway_post_install.agw_post_install.AGWPostInstallChecks.WAIT_FOR_SERVICE_INTERVAL",  # noqa: E501
         new_callable=PropertyMock,
     )
-    def test_given_some_agw_services_not_running_when_check_whether_required_services_are_running_then_AGWServicesNotRunningError_is_raised(  # noqa: E501
+    def test_given_some_agw_services_not_running_when_check_whether_required_services_are_running_then_agwservicesnotrunningerror_is_raised(  # noqa: E501
         self,
         mocked_wait_for_service_interval,
         mocked_timeout_waiting_for_service,
@@ -151,7 +148,7 @@ class TestAGWPostInstallChecks(unittest.TestCase):
         "magma_access_gateway_post_install.agw_post_install.AGWPostInstallChecks.REQUIRED_PACKAGES",  # noqa: E501
         new_callable=PropertyMock,
     )
-    def test_given_not_all_required_magma_packages_are_installed_when_check_whether_required_packages_are_installed_then_AGWPackagesMissingError_is_raised(  # noqa: E501
+    def test_given_not_all_required_magma_packages_are_installed_when_check_whether_required_packages_are_installed_then_agwpackagesmissingerror_is_raised(  # noqa: E501
         self, mocked_required_packages, mocked_call
     ):
         mocked_required_packages.return_value = self.TEST_REQUIRED_PACKAGES
@@ -166,7 +163,7 @@ class TestAGWPostInstallChecks(unittest.TestCase):
         "magma_access_gateway_post_install.agw_post_install.os.path.exists",
         Mock(return_value=False),
     )
-    def test_given_invalid_root_ca_pem_path_when_check_whether_root_certificate_exists_then_AGWRootCertificateMissingError_is_raised(  # noqa: E501
+    def test_given_invalid_root_ca_pem_path_when_check_whether_root_certificate_exists_then_agwrootcertificatemissingerror_is_raised(  # noqa: E501
         self,
     ):
         with self.assertRaises(AGWRootCertificateMissingError):
@@ -176,7 +173,7 @@ class TestAGWPostInstallChecks(unittest.TestCase):
         "magma_access_gateway_post_install.agw_post_install.os.path.exists",
         Mock(return_value=False),
     )
-    def test_given_control_proxy_config_file_missing_when_check_control_proxy_then_AGWControlProxyConfigFileMissingError_is_raised(  # noqa: E501
+    def test_given_control_proxy_config_file_missing_when_check_control_proxy_then_agwcontrolproxyconfigfilemissingerror_is_raised(  # noqa: E501
         self,
     ):
         with self.assertRaises(AGWControlProxyConfigFileMissingError):
@@ -188,7 +185,7 @@ class TestAGWPostInstallChecks(unittest.TestCase):
         "magma_access_gateway_post_install.agw_post_install.os.path.exists",
         Mock(return_value=True),
     )
-    def test_given_control_proxy_config_file_is_missing_required_keys_when_check_control_proxy_then_AGWControlProxyConfigurationError_is_raised(  # noqa: E501
+    def test_given_control_proxy_config_file_is_missing_required_keys_when_check_control_proxy_then_agwcontrolproxyconfigurationerror_is_raised(  # noqa: E501
         self, _, mocked_yaml_safe_load
     ):
         invalid_control_proxy_config_file = {
@@ -204,8 +201,8 @@ class TestAGWPostInstallChecks(unittest.TestCase):
         with self.assertRaises(AGWControlProxyConfigurationError):
             self.agw_post_install.check_control_proxy()
 
-    # def test_given_journal_not_containing_cloud_checkin_logs_when_check_cloud_check_in_then_AGWCloudCheckinError_is_raised(  # noqa: E501
-    #     self,
-    # ):
-    #     with self.assertRaises(AGWCloudCheckinError):
-    #         self.agw_post_install.check_cloud_check_in()
+    def test_given_journal_not_containing_cloud_checkin_logs_when_check_cloud_check_in_then_agwcloudcheckinerror_is_raised(  # noqa: E501
+        self,
+    ):
+        with self.assertRaises(AGWCloudCheckinError):
+            self.agw_post_install.check_cloud_check_in()

--- a/tests/unit/test_agw_post_install.py
+++ b/tests/unit/test_agw_post_install.py
@@ -179,7 +179,7 @@ class TestAGWPostInstallChecks(unittest.TestCase):
         with self.assertRaises(AGWControlProxyConfigFileMissingError):
             self.agw_post_install.check_control_proxy()
 
-    @patch("magma_access_gateway_installer.agw_network_configurator.yaml.safe_load")
+    @patch("magma_access_gateway_post_install.agw_post_install.yaml.safe_load")
     @patch("magma_access_gateway_post_install.agw_post_install.open", new_callable=mock_open())
     @patch(
         "magma_access_gateway_post_install.agw_post_install.os.path.exists",
@@ -201,8 +201,49 @@ class TestAGWPostInstallChecks(unittest.TestCase):
         with self.assertRaises(AGWControlProxyConfigurationError):
             self.agw_post_install.check_control_proxy()
 
+    @patch("magma_access_gateway_post_install.agw_post_install.journal.Reader", new_callable=Mock)
     def test_given_journal_not_containing_cloud_checkin_logs_when_check_cloud_check_in_then_agwcloudcheckinerror_is_raised(  # noqa: E501
-        self,
+        self, mocked_journal_reader
     ):
+        mocked_journal_reader.return_value = MockedJournalReader()
+
         with self.assertRaises(AGWCloudCheckinError):
             self.agw_post_install.check_cloud_check_in()
+
+
+class MockedJournalReader:
+    def __iter__(self):
+        return iter(
+            [
+                {
+                    "PRIORITY": 6,
+                    "_HOSTNAME": "test-host",
+                    "SYSLOG_IDENTIFIER": "magmad",
+                    "_PID": 1111,
+                    "MESSAGE": "Test message without desired text.",
+                },
+                {
+                    "PRIORITY": 6,
+                    "_HOSTNAME": "test-host",
+                    "SYSLOG_IDENTIFIER": "magmad",
+                    "_PID": 1111,
+                    "MESSAGE": "Another test message without desired text.",
+                },
+                {
+                    "PRIORITY": 6,
+                    "_HOSTNAME": "test-host",
+                    "SYSLOG_IDENTIFIER": "magmad",
+                    "_PID": 1111,
+                    "MESSAGE": "One more test message without desired text.",
+                },
+            ]
+        )
+
+    def log_level(self, _):
+        pass
+
+    def this_boot(self):
+        pass
+
+    def add_match(self, *args, **kwargs):
+        pass

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ deps =
     types-setuptools
     types-toml
 commands =
-    mypy -p {[vars]src_path}/magma_access_gateway_configurator -p {[vars]src_path}/magma_access_gateway_installer {posargs}
+    mypy -p {[vars]src_path}/magma_access_gateway_configurator -p {[vars]src_path}/magma_access_gateway_installer -p {[vars]src_path}/magma_access_gateway_post_install {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
This PR implements post-installation checks function of Magma AGW snap. 
After AGW is installed and configured, post-install checks can be run by the operator to make sure everything has been configured configured correctly.
Post-install checks can be run by issuing 
`magma-access-gateway.post-install`

Post-installation checks include:

- interfaces configuration check
- SGi internet connectivity check
- AGW services status check
- required packages check
- Root certificate check
- Control Proxy configuration status check
- Cloud check-in check