### PR TITLE
Telco 144 set custom dns upon agw installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This Snap is currently delivered as a [classic](https://snapcraft.io/docs/snap-c
      using statically configured SGi interface
 
    Magma AGW uses **Google (8.8.8.8)** and **OpenDNS (208.67.222.222)** DNS servers by default. 
-   Default DNS servers can be changed by using `--dns` flag along with `magma-access-gateway` 
+   DNS servers can be changed by using `--dns` flag along with `magma-access-gateway` 
    command. Custom DNS servers should be specified as space separated list of IP addresses.
 
 **Configuring Magma Access Gateway:**

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ This Snap is currently delivered as a [classic](https://snapcraft.io/docs/snap-c
    - `magma-access-gateway --ip-address 1.1.1.1/24 --gw-ip-address 1.1.1.1` - to deploy Magma AGW
      using statically configured SGi interface
 
+   Magma AGW uses **Google (8.8.8.8)** and **OpenDNS (208.67.222.222)** DNS servers by default. 
+   Default DNS servers can be changed by using `--dns` flag along with `magma-access-gateway` 
+   command. Custom DNS servers should be specified as space separated list of IP addresses.
+
 **Configuring Magma Access Gateway:**
 
 Magma Access Gateway can be configured by executing:<br>

--- a/README.md
+++ b/README.md
@@ -33,25 +33,29 @@ This Snap is currently delivered as a [classic](https://snapcraft.io/docs/snap-c
 - [Multipass](https://multipass.run/)
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
-**Building and installing Magma AGW snap:**
+**Building Magma AGW snap:**
 
 1. Install required software listed above
 2. Checkout [magma-access-gateway-snap](https://github.com/canonical/magma-access-gateway-snap)
 3. Inside checked out repository's main directory execute:<br>
    `snapcraft`<br>
-   To see what's happening during Snap's building process, `-d` can be used along with above command.
-4. Once `magma-access-gateway_1.6.0_amd64.snap` file is built, move it to AGW host machine.
-5. On AGW host machine, as `root` execute<br>
+   To see what's happening during Snap's building process, `-d` can be used along with above 
+   command.
+
+**Installing Magma AGW snap:**
+
+1. Copy snap to AGW host machine.
+2. On AGW host machine, as `root` execute<br>
    `snap install ${PATH_TO_THE_SNAP_FILE} --dangerous --classic`<br>
    Since Snap has been built locally, `--dangerous` flag is required to deploy it.
-6. Once Snap is installed (it will be indicated by the `magma-access-gateway 1.6.0 installed`
+3. Once Snap is installed (it will be indicated by the `magma-access-gateway 1.6.0 installed`
    message printed to the console), start AGW deployment by executing:<br>
    - `magma-access-gateway` - to deploy Magma AGW using DHCP configured SGi interface
    - `magma-access-gateway --ip-address 1.1.1.1/24 --gw-ip-address 1.1.1.1` - to deploy Magma AGW
      using statically configured SGi interface
 
    Magma AGW uses **Google (8.8.8.8)** and **OpenDNS (208.67.222.222)** DNS servers by default. 
-   DNS servers can be changed by using `--dns` flag along with `magma-access-gateway` 
+   DNS servers can be configured by using `--dns` flag along with `magma-access-gateway` 
    command. Custom DNS servers should be specified as space separated list of IP addresses.
 
 **Configuring Magma Access Gateway:**

--- a/magma_access_gateway_installer/__init__.py
+++ b/magma_access_gateway_installer/__init__.py
@@ -102,9 +102,5 @@ def validate_args(args):
 
     if not args.dns:
         raise ValueError("--dns flag specified, but no addresses given! Exiting...")
-    else:
-        for dns_ip in args.dns:
-            try:
-                ip_address(dns_ip)
-            except Exception as e:
-                raise e
+    for dns_ip in args.dns:
+        ip_address(dns_ip)

--- a/magma_access_gateway_installer/__init__.py
+++ b/magma_access_gateway_installer/__init__.py
@@ -33,7 +33,7 @@ def main():
 
     preinstall_checks = AGWInstallerPreinstallChecks(network_interfaces)
     network_configurator = AGWInstallerNetworkConfigurator(
-        network_interfaces, args.ip_address, args.gw_ip_address
+        network_interfaces, args.dns, args.ip_address, args.gw_ip_address
     )
     service_user_creator = AGWInstallerServiceUserCreator()
     installation_service_creator = AGWInstallerInstallationServiceCreator()
@@ -69,13 +69,21 @@ def cli_arguments_parser(cli_arguments):
         "--ip-address",
         dest="ip_address",
         required=False,
-        help="Statically allocated SGi interface IP address. Example: 1.1.1.1/24",
+        help="Statically allocated SGi interface IP address. Example: 1.1.1.1/24.",
     )
     cli_options.add_argument(
         "--gw-ip-address",
         dest="gw_ip_address",
         required=False,
-        help="Upstream router IP for SGi interface. Example: 1.1.1.200",
+        help="Upstream router IP for SGi interface. Example: 1.1.1.200.",
+    )
+    cli_options.add_argument(
+        "--dns",
+        dest="dns",
+        nargs="+",
+        required=False,
+        default=["8.8.8.8", "208.67.222.222"],
+        help="Space separated list of DNS IP addresses. Example: --dns 1.2.3.4 5.6.7.8",
     )
     return cli_options.parse_args(cli_arguments)
 
@@ -91,3 +99,12 @@ def validate_args(args):
             ip_address(args.gw_ip_address)
         except Exception as e:
             raise e
+
+    if not args.dns:
+        raise ValueError("--dns flag specified, but no addresses given! Exiting...")
+    else:
+        for dns_ip in args.dns:
+            try:
+                ip_address(dns_ip)
+            except Exception as e:
+                raise e

--- a/magma_access_gateway_installer/agw_network_configurator.py
+++ b/magma_access_gateway_installer/agw_network_configurator.py
@@ -111,11 +111,18 @@ class AGWInstallerNetworkConfigurator:
     @property
     def _dns_configured(self) -> bool:
         """Checks whether DNS has already been configured."""
-        with open(self.ETC_SYSTEMD_RESOLVED_CONF_PATH, "r") as dns_config:
-            for line in dns_config.readlines():
-                if f"DNS={self.dns_ips_list}" in line:
-                    return True
-        return False
+        with open(self.ETC_SYSTEMD_RESOLVED_CONF_PATH, "r") as dns_config_file:
+            dns_config = dns_config_file.readlines()
+        return all(
+            [
+                any(
+                    dns_ip in line
+                    for line in dns_config
+                    if line.startswith("DNS=") or line.startswith("FallbackDNS=")
+                )
+                for dns_ip in self.dns_ips_list
+            ]
+        )
 
     def _configure_dns(self):
         """Configures Ubuntu's DNS."""

--- a/magma_access_gateway_installer/agw_network_configurator.py
+++ b/magma_access_gateway_installer/agw_network_configurator.py
@@ -16,7 +16,6 @@ logger = logging.getLogger("magma_access_gateway_installer")
 
 class AGWInstallerNetworkConfigurator:
 
-    DNS_ADDRESSES = "8.8.8.8 208.67.222.222"
     BOOT_GRUB_GRUB_CFG_PATH = "/boot/grub/grub.cfg"
     CLOUD_INIT_YAML_PATH = "/etc/netplan/50-cloud-init.yaml"
     ETC_DEFAULT_GRUB_PATH = "/etc/default/grub"
@@ -26,9 +25,11 @@ class AGWInstallerNetworkConfigurator:
     def __init__(
         self,
         network_interfaces: list,
+        dns_ip_addresses: list,
         eth0_address: Optional[str],
         eth0_gw_ip_address: Optional[str],
     ):
+        self.dns_ips_list = " ".join(dns_ip_addresses)
         self.eth0_address = eth0_address
         self.eth0_gw_ip_address = eth0_gw_ip_address
         self.network_interfaces = network_interfaces
@@ -112,7 +113,7 @@ class AGWInstallerNetworkConfigurator:
         """Checks whether DNS has already been configured."""
         with open(self.ETC_SYSTEMD_RESOLVED_CONF_PATH, "r") as dns_config:
             for line in dns_config.readlines():
-                if f"DNS={self.DNS_ADDRESSES}" in line:
+                if f"DNS={self.dns_ips_list}" in line:
                     return True
         return False
 
@@ -127,7 +128,7 @@ class AGWInstallerNetworkConfigurator:
         with open(self.ETC_SYSTEMD_RESOLVED_CONF_PATH, "r") as original_resolved_conf_file:
             original_resolved_conf_file_content = original_resolved_conf_file.readlines()
         updated_resolved_conf_file_content = [
-            line.replace(line, f"DNS={self.DNS_ADDRESSES}\n")
+            line.replace(line, f"DNS={self.dns_ips_list}\n")
             if line.startswith("#DNS=") or line.startswith("DNS=")
             else line
             for line in original_resolved_conf_file_content

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -86,7 +86,7 @@ class AGWPostInstallChecks:
             AGWConfigurationError: if eth0 fails to connect to the internet
         """
         logger.info("Checking eth0's internet connectivity...")
-        if not bool(ping(dest_addr="8.8.8.8", interface="eth0")):
+        if not bool(ping(dest_addr="artifactory.magmacore.org", interface="eth0")):
             raise AGWConfigurationError(
                 "eth0 is not connected to the internet!\n"
                 "Make sure the hardware has been properly plugged in (eth0 to internet)."

--- a/tests/unit/test_agw_network_configurator.py
+++ b/tests/unit/test_agw_network_configurator.py
@@ -12,10 +12,11 @@ from magma_access_gateway_installer.agw_network_configurator import (
 
 
 class TestAGWInstallerNetworkConfigurator(unittest.TestCase):
+    TEST_DNS_LIST = ["1.2.3.4", "5.6.7.8"]
     CORRECT_NETWORK_INTERFACES = ["eth0", "eth1"]
     INCORRECT_NETWORK_INTERFACES = ["abc", "def"]
     GOOD_DNS_CONFIG = """[Resolve]
-DNS=8.8.8.8 208.67.222.222
+DNS=1.2.3.4 5.6.7.8
 #FallbackDNS=
 #Domains=
 #LLMNR=no
@@ -83,6 +84,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -97,6 +99,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -111,6 +114,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -131,6 +135,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.INCORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -165,6 +170,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.INCORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -184,6 +190,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.INCORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -204,6 +211,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -225,6 +233,7 @@ ondemand.service                               enabled         enabled
         patch_symlink.return_value = True
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -248,6 +257,7 @@ ondemand.service                               enabled         enabled
         patch_symlink.return_value = True
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -267,6 +277,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -286,6 +297,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -305,6 +317,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -324,6 +337,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -347,6 +361,7 @@ ondemand.service                               enabled         enabled
         ]
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -376,6 +391,7 @@ ondemand.service                               enabled         enabled
         ]
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             test_static_ip_address,
             test_static_gw_ip_address,
         )
@@ -402,6 +418,7 @@ ondemand.service                               enabled         enabled
         ]
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -422,6 +439,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -440,6 +458,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -458,6 +477,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -476,6 +496,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -498,6 +519,7 @@ ondemand.service                               enabled         enabled
         ]
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )

--- a/tests/unit/test_magma_access_gateway_installer.py
+++ b/tests/unit/test_magma_access_gateway_installer.py
@@ -14,6 +14,7 @@ class TestAGWInstallerInit(unittest.TestCase):
     INVALID_TEST_IP_ADDRESS = "321.0.1.5/24"
     VALID_TEST_GW_IP_ADDRESS = "2.3.4.5"
     INVALID_TEST_GW_IP_ADDRESS = "321.3.4.5"
+    DNS_LIST_WITH_INVALID_ADDRESS = ["1.2.3.4", "321.3.4.5", "5.6.7.8"]
 
     def test_given_only_ip_address_cli_argument_is_passed_when_validate_args_then_value_error_is_raised(  # noqa: E501
         self,
@@ -47,6 +48,24 @@ class TestAGWInstallerInit(unittest.TestCase):
         test_args = Namespace(
             ip_address=self.INVALID_TEST_IP_ADDRESS, gw_ip_address=self.VALID_TEST_GW_IP_ADDRESS
         )
+
+        with self.assertRaises(ValueError):
+            magma_access_gateway_installer.validate_args(test_args)
+
+    def test_given_invalid_dns_ip_address_passed_when_validate_args_then_value_error_is_raised(
+        self,
+    ):
+        test_args = Namespace(
+            ip_address=None, gw_ip_address=None, dns=self.DNS_LIST_WITH_INVALID_ADDRESS
+        )
+
+        with self.assertRaises(ValueError):
+            magma_access_gateway_installer.validate_args(test_args)
+
+    def test_given_dns_flag_used_without_any_dns_ips_when_validate_args_then_value_error_is_raised(
+        self,
+    ):
+        test_args = Namespace(ip_address=None, gw_ip_address=None, dns=None)
 
         with self.assertRaises(ValueError):
             magma_access_gateway_installer.validate_args(test_args)


### PR DESCRIPTION
This PR implements possibility of using custom DNS servers with Magma AGW deployment. 
Using Google and OpenDNS DNS servers will not always be desired or possible (due to security policies for instance), hence it should be possible to deploy AGW using arbitrary DNS server.

Space separated DNS servers list can be passed as an argument to `magma-access-gateway` installation command:
`magma-access-gateway --dns 1.2.3.4 5.6.7.8`