### PR TITLE
Telco 145 define sgi and s1 ifaces manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ This Snap is currently delivered as a [classic](https://snapcraft.io/docs/snap-c
    - `magma-access-gateway --ip-address 1.1.1.1/24 --gw-ip-address 1.1.1.1` - to deploy Magma AGW
      using statically configured SGi interface
 
+   Magma AGW uses **Google (8.8.8.8)** and **OpenDNS (208.67.222.222)** DNS servers by default. 
+   Default DNS servers can be changed by using `--dns` flag along with `magma-access-gateway` 
+   command. Custom DNS servers should be specified as space separated list of IP addresses.
+
 **Configuring Magma Access Gateway:**
 
 Magma Access Gateway can be configured by executing:<br>

--- a/magma_access_gateway_configurator/agw_configurator.py
+++ b/magma_access_gateway_configurator/agw_configurator.py
@@ -7,7 +7,6 @@ import os
 import shutil
 from subprocess import check_call
 
-import yaml
 from jinja2 import Environment, FileSystemLoader
 
 logger = logging.getLogger("magma_access_gateway_configurator")
@@ -39,6 +38,7 @@ class AGWConfigurator:
 
     def configure_control_proxy(self):
         """Creates Control Proxy's configuration file."""
+        logger.info("Configuring Control Proxy...")
         if not os.path.exists(self.MAGMA_CONTROL_PROXY_CONFIG_DIR):
             os.makedirs(self.MAGMA_CONTROL_PROXY_CONFIG_DIR)
         if not os.path.exists(
@@ -60,13 +60,12 @@ class AGWConfigurator:
                 ),
                 "w",
             ) as control_proxy_file:
-                yaml.dump(
+                control_proxy_file.write(
                     template.render(
                         domain=self.domain,
                         root_ca_pem_path=self.ROOT_CA_PEM_DESTINATION_DIR,
                         root_ca_pem_file_name=self.ROOT_CA_PEM_FILE_NAME,
                     ),
-                    control_proxy_file,
                 )
 
     def restart_magma_services(self):

--- a/magma_access_gateway_installer/__init__.py
+++ b/magma_access_gateway_installer/__init__.py
@@ -13,6 +13,7 @@ import netifaces  # type: ignore[import]
 from systemd.journal import JournalHandler  # type: ignore[import]
 
 from .agw_installation_service_creator import AGWInstallerInstallationServiceCreator
+from .agw_installer import AGWInstaller
 from .agw_network_configurator import AGWInstallerNetworkConfigurator
 from .agw_preinstall_checks import AGWInstallerPreinstallChecks
 from .agw_service_user_creator import AGWInstallerServiceUserCreator
@@ -45,23 +46,24 @@ def main():
         network_configurator.update_interfaces_names()
         network_configurator.configure_dns()
         network_configurator.create_interfaces_config_files()
-        network_configurator.remove_netplan()
-        network_configurator.enable_networking_service()
+    network_configurator.remove_netplan()
+    network_configurator.enable_networking_service()
 
     service_user_creator.create_magma_user()
     service_user_creator.add_magma_user_to_sudo_group()
     service_user_creator.add_magma_user_to_sudoers_file()
 
-    installation_service_creator.create_magma_agw_installation_service()
-    installation_service_creator.create_magma_agw_installation_service_link()
-
     if network_configurator.reboot_needed:
+        installation_service_creator.create_magma_agw_installation_service()
+        installation_service_creator.create_magma_agw_installation_service_link()
         logger.info(
             "Rebooting system to apply pre-installation changes...\n"
             "Magma AGW installation process will be resumed automatically once machine is back up."
         )
         time.sleep(5)
         os.system("reboot")
+    else:
+        AGWInstaller().install()
 
 
 def cli_arguments_parser(cli_arguments):

--- a/magma_access_gateway_installer/__init__.py
+++ b/magma_access_gateway_installer/__init__.py
@@ -41,7 +41,7 @@ def main():
     preinstall_checks.preinstall_checks()
     preinstall_checks.install_required_system_packages()
 
-    if not args.maas_networking:
+    if not args.skip_networking:
         network_configurator.update_interfaces_names()
         network_configurator.configure_dns()
         network_configurator.create_interfaces_config_files()
@@ -79,12 +79,12 @@ def cli_arguments_parser(cli_arguments):
         help="Upstream router IP for SGi interface. Example: 1.1.1.200.",
     )
     cli_options.add_argument(
-        "--maas-networking",
-        dest="maas_networking",
+        "--skip-networking",
+        dest="skip_networking",
         action="store_true",
         required=False,
-        help="Use network configuration provided by MAAS. If used, network configuration part of "
-        "the installation process will be skipped.",
+        help="If used, network configuration part of the installation process will be skipped. "
+        "In this case operator is responsible for providing expected network configuration.",
     )
     cli_options.add_argument(
         "--dns",

--- a/magma_access_gateway_installer/__init__.py
+++ b/magma_access_gateway_installer/__init__.py
@@ -25,15 +25,15 @@ logger.setLevel(logging.INFO)
 
 
 def main():
-    args = cli_arguments_parser(sys.argv[1:])
-    validate_args(args)
-
     network_interfaces = netifaces.interfaces()
     network_interfaces.remove("lo")
 
+    args = cli_arguments_parser(sys.argv[1:])
+    validate_args(args, network_interfaces)
+
     preinstall_checks = AGWInstallerPreinstallChecks(network_interfaces)
     network_configurator = AGWInstallerNetworkConfigurator(
-        network_interfaces, args.dns, args.ip_address, args.gw_ip_address
+        network_interfaces, args.dns, args.ip_address, args.gw_ip_address, args.sgi, args.s1
     )
     service_user_creator = AGWInstallerServiceUserCreator()
     installation_service_creator = AGWInstallerInstallationServiceCreator()
@@ -41,11 +41,12 @@ def main():
     preinstall_checks.preinstall_checks()
     preinstall_checks.install_required_system_packages()
 
-    network_configurator.update_interfaces_names()
-    network_configurator.configure_dns()
-    network_configurator.create_interfaces_config_files()
-    network_configurator.remove_netplan()
-    network_configurator.enable_networking_service()
+    if not args.maas_networking:
+        network_configurator.update_interfaces_names()
+        network_configurator.configure_dns()
+        network_configurator.create_interfaces_config_files()
+        network_configurator.remove_netplan()
+        network_configurator.enable_networking_service()
 
     service_user_creator.create_magma_user()
     service_user_creator.add_magma_user_to_sudo_group()
@@ -78,17 +79,64 @@ def cli_arguments_parser(cli_arguments):
         help="Upstream router IP for SGi interface. Example: 1.1.1.200.",
     )
     cli_options.add_argument(
+        "--maas-networking",
+        dest="maas_networking",
+        action="store_true",
+        required=False,
+        help="Use network configuration provided by MAAS. If used, network configuration part of "
+        "the installation process will be skipped.",
+    )
+    cli_options.add_argument(
         "--dns",
         dest="dns",
         nargs="+",
         required=False,
         default=["8.8.8.8", "208.67.222.222"],
-        help="Space separated list of DNS IP addresses. Example: --dns 1.2.3.4 5.6.7.8",
+        help="Space separated list of DNS IP addresses. Example: --dns 1.2.3.4 5.6.7.8.",
+    )
+    cli_options.add_argument(
+        "--sgi",
+        dest="sgi",
+        required=False,
+        help="Defines which interface should be used as SGi interface.",
+    )
+    cli_options.add_argument(
+        "--s1",
+        dest="s1",
+        required=False,
+        help="Defines which interface should be used as S1 interface.",
     )
     return cli_options.parse_args(cli_arguments)
 
 
-def validate_args(args):
+def validate_args(args, network_interfaces):
+    validate_static_ip_allocation(args)
+    validate_arbitrary_dns(args)
+    validate_custom_sgi_and_s1_interfaces(args, network_interfaces)
+
+
+def validate_custom_sgi_and_s1_interfaces(args, network_interfaces):
+    if args.sgi and not args.s1:
+        raise ValueError("S1 interface not specified! Exiting...")
+    elif not args.sgi and args.s1:
+        raise ValueError("SGi interface not specified! Exiting...")
+    elif args.sgi and args.s1:
+        if not all([interface in network_interfaces for interface in [args.sgi, args.s1]]):
+            raise ValueError("One or both specified SGi/S1 interfaces do not exist! Exiting...")
+
+
+def validate_arbitrary_dns(args):
+    if not args.dns:
+        raise ValueError("--dns flag specified, but no addresses given! Exiting...")
+    else:
+        for dns_ip in args.dns:
+            try:
+                ip_address(dns_ip)
+            except Exception as e:
+                raise e
+
+
+def validate_static_ip_allocation(args):
     if args.ip_address and not args.gw_ip_address:
         raise ValueError("Upstream router IP for SGi interface is missing! Exiting...")
     elif not args.ip_address and args.gw_ip_address:
@@ -99,12 +147,3 @@ def validate_args(args):
             ip_address(args.gw_ip_address)
         except Exception as e:
             raise e
-
-    if not args.dns:
-        raise ValueError("--dns flag specified, but no addresses given! Exiting...")
-    else:
-        for dns_ip in args.dns:
-            try:
-                ip_address(dns_ip)
-            except Exception as e:
-                raise e

--- a/magma_access_gateway_installer/__init__.py
+++ b/magma_access_gateway_installer/__init__.py
@@ -8,6 +8,7 @@ import sys
 import time
 from argparse import ArgumentParser
 from ipaddress import ip_address, ip_network
+from typing import List
 
 import netifaces  # type: ignore[import]
 from systemd.journal import JournalHandler  # type: ignore[import]
@@ -111,20 +112,17 @@ def cli_arguments_parser(cli_arguments):
     return cli_options.parse_args(cli_arguments)
 
 
-def validate_args(args, network_interfaces):
+def validate_args(args, network_interfaces: List[str]):
     validate_static_ip_allocation(args)
     validate_arbitrary_dns(args)
     validate_custom_sgi_and_s1_interfaces(args, network_interfaces)
 
 
-def validate_custom_sgi_and_s1_interfaces(args, network_interfaces):
-    if args.sgi and not args.s1:
-        raise ValueError("S1 interface not specified! Exiting...")
-    elif not args.sgi and args.s1:
-        raise ValueError("SGi interface not specified! Exiting...")
-    elif args.sgi and args.s1:
-        if not all([interface in network_interfaces for interface in [args.sgi, args.s1]]):
-            raise ValueError("One or both specified SGi/S1 interfaces do not exist! Exiting...")
+def validate_custom_sgi_and_s1_interfaces(args, network_interfaces: List[str]):
+    if not args.sgi or args.sgi not in network_interfaces:
+        raise ValueError("Invalid or empty SGi interface specified! Exiting...")
+    if not args.s1 or args.s1 not in network_interfaces:
+        raise ValueError("Invalid or empty S1 interface specified! Exiting...")
 
 
 def validate_arbitrary_dns(args):

--- a/magma_access_gateway_installer/__init__.py
+++ b/magma_access_gateway_installer/__init__.py
@@ -33,7 +33,7 @@ def main():
 
     preinstall_checks = AGWInstallerPreinstallChecks(network_interfaces)
     network_configurator = AGWInstallerNetworkConfigurator(
-        network_interfaces, args.ip_address, args.gw_ip_address
+        network_interfaces, args.dns, args.ip_address, args.gw_ip_address
     )
     service_user_creator = AGWInstallerServiceUserCreator()
     installation_service_creator = AGWInstallerInstallationServiceCreator()
@@ -69,13 +69,21 @@ def cli_arguments_parser(cli_arguments):
         "--ip-address",
         dest="ip_address",
         required=False,
-        help="Statically allocated SGi interface IP address. Example: 1.1.1.1/24",
+        help="Statically allocated SGi interface IP address. Example: 1.1.1.1/24.",
     )
     cli_options.add_argument(
         "--gw-ip-address",
         dest="gw_ip_address",
         required=False,
-        help="Upstream router IP for SGi interface. Example: 1.1.1.200",
+        help="Upstream router IP for SGi interface. Example: 1.1.1.200.",
+    )
+    cli_options.add_argument(
+        "--dns",
+        dest="dns",
+        nargs="+",
+        required=False,
+        default=["8.8.8.8", "208.67.222.222"],
+        help="Space separated list of DNS IP addresses. Example: --dns 1.2.3.4 5.6.7.8",
     )
     return cli_options.parse_args(cli_arguments)
 
@@ -91,3 +99,12 @@ def validate_args(args):
             ip_address(args.gw_ip_address)
         except Exception as e:
             raise e
+
+    if not args.dns:
+        raise ValueError("--dns flag specified, but no addresses given! Exiting...")
+    else:
+        for dns_ip in args.dns:
+            try:
+                ip_address(dns_ip)
+            except Exception as e:
+                raise e

--- a/magma_access_gateway_installer/agw_installation_errors.py
+++ b/magma_access_gateway_installer/agw_installation_errors.py
@@ -28,7 +28,7 @@ class InvalidNumberOfInterfacesError(AGWInstallationError):
 
     ERROR_MESSAGE = (
         "Invalid number of network interfaces! \n"
-        "Magma AGW needs two network interfaces - SGi and S1! Exiting..."
+        "Magma AGW needs at least two network interfaces available - SGi and S1! Exiting..."
     )
 
     def __init__(self):

--- a/magma_access_gateway_installer/agw_installer.py
+++ b/magma_access_gateway_installer/agw_installer.py
@@ -136,7 +136,7 @@ class AGWInstaller:
                 "apt-key",
                 "adv",
                 "--fetch-keys",
-                "https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public",
+                "https://artifactory.magmacore.org/artifactory/api/gpg/key/public",
             ]
         )
         self._ignore_magma_apt_repositorys_ssl_cert()

--- a/magma_access_gateway_installer/agw_network_configurator.py
+++ b/magma_access_gateway_installer/agw_network_configurator.py
@@ -5,8 +5,9 @@
 import logging
 import os
 from copy import deepcopy
+from pathlib import Path
 from subprocess import check_call, check_output
-from typing import Optional
+from typing import List, Optional, Union
 
 import ipcalc  # type: ignore[import]
 import yaml
@@ -24,8 +25,8 @@ class AGWInstallerNetworkConfigurator:
 
     def __init__(
         self,
-        network_interfaces: list,
-        dns_ip_addresses: list,
+        network_interfaces: List[str],
+        dns_ip_addresses: List[str],
         eth0_address: Optional[str] = None,
         eth0_gw_ip_address: Optional[str] = None,
         sgi_interface: Optional[str] = None,
@@ -87,7 +88,7 @@ class AGWInstallerNetworkConfigurator:
             logger.info(f"Changing interface name in {netplan_config_file}.")
             self._rename_interfaces_in_netplan_config_file(netplan_config_file)
 
-    def _rename_interfaces_in_netplan_config_file(self, config_file):
+    def _rename_interfaces_in_netplan_config_file(self, config_file: Union[str, Path]):
         """Renames interfaces names in given netplan config file."""
         with open(config_file, "r") as netplan_config_file:
             initial_netplan_config_content = yaml.safe_load(netplan_config_file)
@@ -96,7 +97,7 @@ class AGWInstallerNetworkConfigurator:
         with open(config_file, "w") as netplan_config_file:
             yaml.dump(modified_netplan_config_content, netplan_config_file)
 
-    def _rename_interfaces(self, netplan_config):
+    def _rename_interfaces(self, netplan_config: dict):
         """Automatically renames interfaces based on previously generated names mapping."""
         for network_interface in self.interfaces_names_mapping.keys():
             try:
@@ -109,7 +110,9 @@ class AGWInstallerNetworkConfigurator:
                 pass
 
     @staticmethod
-    def _rename_interface(cloud_init_content, old_interface_name, new_interface_name):
+    def _rename_interface(
+        cloud_init_content: dict, old_interface_name: str, new_interface_name: str
+    ):
         """Renames given interface in netplan config."""
         logger.info(
             f"Old interface name: {old_interface_name} "

--- a/magma_access_gateway_installer/agw_network_configurator.py
+++ b/magma_access_gateway_installer/agw_network_configurator.py
@@ -16,7 +16,6 @@ logger = logging.getLogger("magma_access_gateway_installer")
 
 class AGWInstallerNetworkConfigurator:
 
-    DNS_ADDRESSES = "8.8.8.8 208.67.222.222"
     BOOT_GRUB_GRUB_CFG_PATH = "/boot/grub/grub.cfg"
     CLOUD_INIT_YAML_PATH = "/etc/netplan/50-cloud-init.yaml"
     ETC_DEFAULT_GRUB_PATH = "/etc/default/grub"
@@ -26,9 +25,11 @@ class AGWInstallerNetworkConfigurator:
     def __init__(
         self,
         network_interfaces: list,
+        dns_ip_addresses: list,
         eth0_address: Optional[str],
         eth0_gw_ip_address: Optional[str],
     ):
+        self.dns_ips_list = " ".join(dns_ip_addresses)
         self.eth0_address = eth0_address
         self.eth0_gw_ip_address = eth0_gw_ip_address
         self.network_interfaces = network_interfaces
@@ -112,7 +113,7 @@ class AGWInstallerNetworkConfigurator:
         """Checks whether DNS has already been configured."""
         with open(self.ETC_SYSTEMD_RESOLVED_CONF_PATH, "r") as dns_config:
             for line in dns_config.readlines():
-                if f"DNS={self.DNS_ADDRESSES}" in line:
+                if f"DNS={self.dns_ips_list}" in line:
                     return True
         return False
 
@@ -127,7 +128,7 @@ class AGWInstallerNetworkConfigurator:
         with open(self.ETC_SYSTEMD_RESOLVED_CONF_PATH, "r") as original_resolved_conf_file:
             original_resolved_conf_file_content = original_resolved_conf_file.readlines()
         updated_resolved_conf_file_content = [
-            line.replace(line, f"DNS={self.DNS_ADDRESSES}\n")
+            line.replace(line, f"DNS={self.dns_ips_list}\n")
             if line.startswith("#DNS=") or line.startswith("DNS=")
             else line
             for line in original_resolved_conf_file_content

--- a/magma_access_gateway_installer/agw_preinstall_checks.py
+++ b/magma_access_gateway_installer/agw_preinstall_checks.py
@@ -52,4 +52,4 @@ class AGWInstallerPreinstallChecks:
     @property
     def _required_amount_of_network_interfaces_is_available(self) -> bool:
         """Checks whether required amount of network interfaces has been attached."""
-        return len(self.network_interfaces) == self.REQUIRED_NUMBER_OF_NICS
+        return len(self.network_interfaces) >= self.REQUIRED_NUMBER_OF_NICS

--- a/magma_access_gateway_post_install/__init__.py
+++ b/magma_access_gateway_post_install/__init__.py
@@ -9,8 +9,6 @@
 """
 
 import logging
-import sys
-from argparse import ArgumentParser
 
 from systemd.journal import JournalHandler  # type: ignore[import]
 
@@ -24,9 +22,7 @@ logger.setLevel(logging.INFO)
 
 
 def main():
-    args = cli_arguments_parser(sys.argv[1:])
-
-    agw_post_install_checks = AGWPostInstallChecks(args.root_ca_path)
+    agw_post_install_checks = AGWPostInstallChecks()
 
     logger.info("Starting Magma AGW post-installation checks...")
     agw_post_install_checks.check_whether_required_interfaces_are_configured()
@@ -37,14 +33,3 @@ def main():
     agw_post_install_checks.check_control_proxy()
     agw_post_install_checks.check_cloud_check_in()
     logger.info("Magma AGW post-installation checks finished successfully.")
-
-
-def cli_arguments_parser(cli_arguments):
-    cli_options = ArgumentParser()
-    cli_options.add_argument(
-        "--root-ca-pem-path",
-        dest="root_ca_path",
-        required=True,
-        help="Path to Root CA PEM used during Orc8r deployment. Example: /home/magma/rootCA.pem",
-    )
-    return cli_options.parse_args(cli_arguments)

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -57,9 +57,6 @@ class AGWPostInstallChecks:
     TIMEOUT_WAITING_FOR_SERVICE = 60
     WAIT_FOR_SERVICE_INTERVAL = 10
 
-    def __init__(self, root_ca_pem_path: str):
-        self.root_ca_pem_path = root_ca_pem_path
-
     def check_whether_required_interfaces_are_configured(self):
         """Checks whether Magma AGW interfaces are configured or not.
 
@@ -120,14 +117,15 @@ class AGWPostInstallChecks:
         ]:
             raise AGWPackagesMissingError(missing_packages)
 
-    def check_whether_root_certificate_exists(self):
+    @staticmethod
+    def check_whether_root_certificate_exists():
         """Checks whether rootCA.pem certificate exists under /var/opt/magma/tmp/certs/.
 
         :raises:
             AGWRootCertificateMissingError: if the certificate is missing
         """
         logger.info("Checking whether Root Certificate exists...")
-        if not os.path.exists(os.path.join("/var/opt/magma/tmp/certs", self.root_ca_pem_path)):
+        if not os.path.exists("/var/opt/magma/tmp/certs/rootCA.pem"):
             raise AGWRootCertificateMissingError()
 
     def check_control_proxy(self):

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -86,7 +86,7 @@ class AGWPostInstallChecks:
             AGWConfigurationError: if eth0 fails to connect to the internet
         """
         logger.info("Checking eth0's internet connectivity...")
-        if not bool(ping(dest_addr="8.8.8.8", interface="eth0")):
+        if not bool(ping(dest_addr="artifactory.magmacore.org", interface="eth0")):
             raise AGWConfigurationError(
                 "eth0 is not connected to the internet!\n"
                 "Make sure the hardware has been properly plugged in (eth0 to internet)."

--- a/tests/unit/test_agw_configurator.py
+++ b/tests/unit/test_agw_configurator.py
@@ -4,7 +4,7 @@
 
 import os
 import unittest
-from unittest.mock import Mock, PropertyMock, call, patch
+from unittest.mock import Mock, PropertyMock, call, mock_open, patch
 
 from magma_access_gateway_configurator.agw_configurator import AGWConfigurator
 
@@ -111,11 +111,10 @@ class TestAGWConfigurator(unittest.TestCase):
 
         mocked_makedirs.assert_not_called()
 
-    @patch("magma_access_gateway_installer.agw_network_configurator.yaml.dump")
     @patch("magma_access_gateway_configurator.agw_configurator.os.path.exists")
-    @patch("magma_access_gateway_configurator.agw_configurator.open")
+    @patch("magma_access_gateway_configurator.agw_configurator.open", new_callable=mock_open)
     def test_given_non_existent_control_proxy_config_file_when_configure_control_proxy_then_control_proxy_config_file_is_created_with_correct_content(  # noqa: E501
-        self, mocked_open, mocked_path_exists, mocked_yaml_dump
+        self, mocked_open, mocked_path_exists
     ):
         expected_control_proxy_config = f"""cloud_address: controller.{self.TEST_DOMAIN}
 cloud_port: 443
@@ -137,7 +136,6 @@ rootca_cert: {self.TEST_ROOT_CA_PEM_DESTINATION_DIR}/{self.TEST_ROOT_CA_PEM_FILE
             self.agw_configurator.configure_control_proxy()
         # fmt: on
 
-        args, kwargs = mocked_yaml_dump.call_args
         mocked_open.assert_called_once_with(
             os.path.join(
                 self.TEST_MAGMA_CONTROL_PROXY_CONFIG_DIR,
@@ -145,8 +143,7 @@ rootca_cert: {self.TEST_ROOT_CA_PEM_DESTINATION_DIR}/{self.TEST_ROOT_CA_PEM_FILE
             ),
             "w",
         )
-        self.assertEqual(args[0], expected_control_proxy_config)
-        self.assertEqual(mocked_yaml_dump.call_count, 1)
+        mocked_open().write.assert_called_once_with(expected_control_proxy_config)
 
     @patch("magma_access_gateway_configurator.agw_configurator.os.path.exists")
     @patch("magma_access_gateway_configurator.agw_configurator.open")

--- a/tests/unit/test_agw_installer.py
+++ b/tests/unit/test_agw_installer.py
@@ -167,7 +167,7 @@ Verify-Host "false";
                     "apt-key",
                     "adv",
                     "--fetch-keys",
-                    "https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public",
+                    "https://artifactory.magmacore.org/artifactory/api/gpg/key/public",
                 ]
             )
             in mock_check_call.mock_calls

--- a/tests/unit/test_agw_network_configurator.py
+++ b/tests/unit/test_agw_network_configurator.py
@@ -12,10 +12,11 @@ from magma_access_gateway_installer.agw_network_configurator import (
 
 
 class TestAGWInstallerNetworkConfigurator(unittest.TestCase):
+    TEST_DNS_LIST = ["1.2.3.4", "5.6.7.8"]
     CORRECT_NETWORK_INTERFACES = ["eth0", "eth1"]
     INCORRECT_NETWORK_INTERFACES = ["abc", "def"]
     GOOD_DNS_CONFIG = """[Resolve]
-DNS=8.8.8.8 208.67.222.222
+DNS=1.2.3.4 5.6.7.8
 #FallbackDNS=
 #Domains=
 #LLMNR=no
@@ -83,6 +84,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -97,6 +99,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -111,6 +114,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -131,6 +135,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.INCORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -165,6 +170,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.INCORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -184,6 +190,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.INCORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -204,6 +211,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -225,6 +233,7 @@ ondemand.service                               enabled         enabled
         patch_symlink.return_value = True
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -248,6 +257,7 @@ ondemand.service                               enabled         enabled
         patch_symlink.return_value = True
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -267,6 +277,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -286,6 +297,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -305,6 +317,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -324,6 +337,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -347,6 +361,7 @@ ondemand.service                               enabled         enabled
         ]
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -376,6 +391,7 @@ ondemand.service                               enabled         enabled
         ]
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             test_static_ip_address,
             test_static_gw_ip_address,
         )
@@ -402,6 +418,7 @@ ondemand.service                               enabled         enabled
         ]
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -422,6 +439,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -440,6 +458,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -458,6 +477,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -476,6 +496,7 @@ ondemand.service                               enabled         enabled
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )
@@ -498,6 +519,7 @@ ondemand.service                               enabled         enabled
         ]
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.CORRECT_NETWORK_INTERFACES,
+            self.TEST_DNS_LIST,
             None,
             None,
         )

--- a/tests/unit/test_agw_network_configurator.py
+++ b/tests/unit/test_agw_network_configurator.py
@@ -39,21 +39,49 @@ DNS=1.2.3.4 5.6.7.8
 #DNSStubListener=yes
 #ReadEtcHosts=yes
 """
+    TEST_INTERFACES_CONFIGS = {
+        "test_if_name": {
+            "dhcp4": True,
+            "dhcp6": False,
+            "match": {"macaddress": "02:45:b8:e6:23:c6"},
+            "set-name": "test_if_name",
+        },
+        "test_if_name_2": {
+            "dhcp4": True,
+            "dhcp6": False,
+            "match": {"macaddress": "02:45:b8:e6:c6:23"},
+            "set-name": "test_if_name_2",
+        },
+        "test_if_name_3": {
+            "dhcp4": True,
+            "dhcp6": False,
+            "match": {"macaddress": "02:45:23:e6:c6:b8"},
+            "set-name": "test_if_name_3",
+        },
+        "test_if_name_4": {
+            "dhcp4": True,
+            "dhcp6": False,
+            "match": {"macaddress": "02:23:b8:e6:c6:45"},
+            "set-name": "test_if_name_4",
+        },
+        "eth0": {
+            "dhcp4": True,
+            "dhcp6": False,
+            "match": {"macaddress": "02:45:b8:e6:23:c6"},
+            "set-name": "eth0",
+        },
+        "eth1": {
+            "dhcp4": True,
+            "dhcp6": False,
+            "match": {"macaddress": "02:45:b8:e6:c6:23"},
+            "set-name": "eth1",
+        },
+    }
     CLOUD_INIT_CONTENT_2_INTERFACES_ONLY = {
         "network": {
             "ethernets": {
-                "test_if_name": {
-                    "dhcp4": True,
-                    "dhcp6": False,
-                    "match": {"macaddress": "02:45:b8:e6:23:c6"},
-                    "set-name": "test_if_name",
-                },
-                "test_if_name_2": {
-                    "dhcp4": True,
-                    "dhcp6": False,
-                    "match": {"macaddress": "02:45:b8:e6:c6:23"},
-                    "set-name": "test_if_name_2",
-                },
+                "test_if_name": TEST_INTERFACES_CONFIGS["test_if_name"],
+                "test_if_name_2": TEST_INTERFACES_CONFIGS["test_if_name_2"],
             },
             "version": 2,
         }
@@ -61,36 +89,16 @@ DNS=1.2.3.4 5.6.7.8
     CLOUD_INIT_CONTENT_MORE_INTERFACES = {
         "network": {
             "ethernets": {
-                "test_if_name": {
-                    "dhcp4": True,
-                    "dhcp6": False,
-                    "match": {"macaddress": "02:45:b8:e6:23:c6"},
-                    "set-name": "test_if_name",
-                },
-                "test_if_name_2": {
-                    "dhcp4": True,
-                    "dhcp6": False,
-                    "match": {"macaddress": "02:45:b8:e6:c6:23"},
-                    "set-name": "test_if_name_2",
-                },
-                "test_if_name_3": {
-                    "dhcp4": True,
-                    "dhcp6": False,
-                    "match": {"macaddress": "02:45:23:e6:c6:b8"},
-                    "set-name": "test_if_name_3",
-                },
-                "test_if_name_4": {
-                    "dhcp4": True,
-                    "dhcp6": False,
-                    "match": {"macaddress": "02:23:b8:e6:c6:45"},
-                    "set-name": "test_if_name_4",
-                },
+                "test_if_name": TEST_INTERFACES_CONFIGS["test_if_name"],
+                "test_if_name_2": TEST_INTERFACES_CONFIGS["test_if_name_2"],
+                "test_if_name_3": TEST_INTERFACES_CONFIGS["test_if_name_3"],
+                "test_if_name_4": TEST_INTERFACES_CONFIGS["test_if_name_4"],
             },
             "version": 2,
         }
     }
-    TEST_SGi_INTERFACE = "test_if_name_2"
-    TEST_S1_INTERFACE = "test_if_name_4"
+    TEST_SGi_INTERFACE = "test_if_name"
+    TEST_S1_INTERFACE = "test_if_name_2"
     APT_LIST_WITH_NETPLAN = """netcat-openbsd/focal,now 1.206-1ubuntu1 amd64 [installed,automatic]
 netpbm/focal,now 2:10.0-15.3build1 amd64 [installed,automatic]
 netplan.io/focal-updates,now 0.103-0ubuntu5~20.04.5 amd64 [installed,automatic]
@@ -173,18 +181,8 @@ ondemand.service                               enabled         enabled
         expected_cloud_init_content = {
             "network": {
                 "ethernets": {
-                    "eth0": {
-                        "dhcp4": True,
-                        "dhcp6": False,
-                        "match": {"macaddress": "02:45:b8:e6:23:c6"},
-                        "set-name": "eth0",
-                    },
-                    "eth1": {
-                        "dhcp4": True,
-                        "dhcp6": False,
-                        "match": {"macaddress": "02:45:b8:e6:c6:23"},
-                        "set-name": "eth1",
-                    },
+                    "eth0": self.TEST_INTERFACES_CONFIGS["eth0"],
+                    "eth1": self.TEST_INTERFACES_CONFIGS["eth1"],
                 },
                 "version": 2,
             }
@@ -206,6 +204,7 @@ ondemand.service                               enabled         enabled
     def test_given_custom_sgi_and_s1_interfaces_names_when_update_interfaces_names_then_netplan_config_file_is_updated(  # noqa: E501
         self, _, __, ___, mock_yaml_dump
     ):
+        self.maxDiff = None
         agw_network_configurator = AGWInstallerNetworkConfigurator(
             self.INCORRECT_NETWORK_INTERFACES,
             self.TEST_DNS_LIST,
@@ -215,30 +214,10 @@ ondemand.service                               enabled         enabled
         expected_cloud_init_content = {
             "network": {
                 "ethernets": {
-                    "test_if_name": {
-                        "dhcp4": True,
-                        "dhcp6": False,
-                        "match": {"macaddress": "02:45:b8:e6:23:c6"},
-                        "set-name": "test_if_name",
-                    },
-                    "eth0": {
-                        "dhcp4": True,
-                        "dhcp6": False,
-                        "match": {"macaddress": "02:45:b8:e6:c6:23"},
-                        "set-name": "eth0",
-                    },
-                    "test_if_name_3": {
-                        "dhcp4": True,
-                        "dhcp6": False,
-                        "match": {"macaddress": "02:45:23:e6:c6:b8"},
-                        "set-name": "test_if_name_3",
-                    },
-                    "eth1": {
-                        "dhcp4": True,
-                        "dhcp6": False,
-                        "match": {"macaddress": "02:23:b8:e6:c6:45"},
-                        "set-name": "eth1",
-                    },
+                    "eth0": self.TEST_INTERFACES_CONFIGS["eth0"],
+                    "eth1": self.TEST_INTERFACES_CONFIGS["eth1"],
+                    "test_if_name_3": self.TEST_INTERFACES_CONFIGS["test_if_name_3"],
+                    "test_if_name_4": self.TEST_INTERFACES_CONFIGS["test_if_name_4"],
                 },
                 "version": 2,
             }

--- a/tests/unit/test_agw_network_configurator.py
+++ b/tests/unit/test_agw_network_configurator.py
@@ -163,7 +163,7 @@ ondemand.service                               enabled         enabled
     )
     @patch("magma_access_gateway_installer.agw_network_configurator.open", new_callable=mock_open)
     @patch("magma_access_gateway_installer.agw_network_configurator.check_call")
-    def test_given_interfaces_dont_have_correct_names_when_update_interfaces_names_then_grub_configuration_file_is_updated(  # noqa: E501
+    def test_given_interfaces_dont_have_correct_names_when_update_interfaces_names_then_netplan_config_file_is_updated(  # noqa: E501
         self, _, __, ___, mock_yaml_dump
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(
@@ -203,7 +203,7 @@ ondemand.service                               enabled         enabled
     )
     @patch("magma_access_gateway_installer.agw_network_configurator.open", new_callable=mock_open)
     @patch("magma_access_gateway_installer.agw_network_configurator.check_call")
-    def test_given_custom_sgi_and_s1_interfaces_names_when_update_interfaces_names_then_grub_configuration_file_is_updated(  # noqa: E501
+    def test_given_custom_sgi_and_s1_interfaces_names_when_update_interfaces_names_then_netplan_config_file_is_updated(  # noqa: E501
         self, _, __, ___, mock_yaml_dump
     ):
         agw_network_configurator = AGWInstallerNetworkConfigurator(

--- a/tests/unit/test_agw_network_configurator.py
+++ b/tests/unit/test_agw_network_configurator.py
@@ -14,7 +14,7 @@ from magma_access_gateway_installer.agw_network_configurator import (
 class TestAGWInstallerNetworkConfigurator(unittest.TestCase):
     TEST_DNS_LIST = ["1.2.3.4", "5.6.7.8"]
     CORRECT_NETWORK_INTERFACES = ["eth0", "eth1"]
-    INCORRECT_NETWORK_INTERFACES = ["abc", "def"]
+    INCORRECT_NETWORK_INTERFACES = ["test_if_name", "test_if_name_2"]
     GOOD_DNS_CONFIG = """[Resolve]
 DNS=1.2.3.4 5.6.7.8
 #FallbackDNS=

--- a/tests/unit/test_agw_post_install.py
+++ b/tests/unit/test_agw_post_install.py
@@ -27,7 +27,7 @@ class TestAGWPostInstallChecks(unittest.TestCase):
     TEST_REQUIRED_PACKAGES = ["package1", "package2", "package3"]
 
     def setUp(self) -> None:
-        self.agw_post_install = AGWPostInstallChecks("/test/root/ca/pem/path")
+        self.agw_post_install = AGWPostInstallChecks()
 
     @patch("magma_access_gateway_post_install.agw_post_install.os.path.exists")
     @patch(

--- a/tests/unit/test_magma_access_gateway_installer.py
+++ b/tests/unit/test_magma_access_gateway_installer.py
@@ -14,7 +14,13 @@ class TestAGWInstallerInit(unittest.TestCase):
     INVALID_TEST_IP_ADDRESS = "321.0.1.5/24"
     VALID_TEST_GW_IP_ADDRESS = "2.3.4.5"
     INVALID_TEST_GW_IP_ADDRESS = "321.3.4.5"
+    DNS_LIST_WITH_VALID_ADDRESS = ["1.2.3.4", "5.6.7.8"]
     DNS_LIST_WITH_INVALID_ADDRESS = ["1.2.3.4", "321.3.4.5", "5.6.7.8"]
+    TEST_INTERFACES_LIST = ["bear", "rabbit", "eagle", "moose"]
+    VALID_TEST_SGi_INTERFACE_NAME = "rabbit"
+    INVALID_TEST_SGi_INTERFACE_NAME = "wolf"
+    VALID_TEST_S1_INTERFACE_NAME = "moose"
+    INVALID_TEST_S1_INTERFACE_NAME = "snake"
 
     def test_given_only_ip_address_cli_argument_is_passed_when_validate_args_then_value_error_is_raised(  # noqa: E501
         self,
@@ -22,7 +28,7 @@ class TestAGWInstallerInit(unittest.TestCase):
         test_args = Namespace(ip_address=self.VALID_TEST_IP_ADDRESS, gw_ip_address=None)
 
         with self.assertRaises(ValueError):
-            magma_access_gateway_installer.validate_args(test_args)
+            magma_access_gateway_installer.validate_args(test_args, self.TEST_INTERFACES_LIST)
 
     def test_given_only_gw_ip_address_cli_argument_is_passed_when_validate_args_then_value_error_is_raised(  # noqa: E501
         self,
@@ -30,7 +36,7 @@ class TestAGWInstallerInit(unittest.TestCase):
         test_args = Namespace(ip_address=None, gw_ip_address=self.VALID_TEST_GW_IP_ADDRESS)
 
         with self.assertRaises(ValueError):
-            magma_access_gateway_installer.validate_args(test_args)
+            magma_access_gateway_installer.validate_args(test_args, self.TEST_INTERFACES_LIST)
 
     def test_given_invalid_gw_ip_address_cli_argument_is_passed_when_validate_args_then_value_error_is_raised(  # noqa: E501
         self,
@@ -40,7 +46,7 @@ class TestAGWInstallerInit(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError):
-            magma_access_gateway_installer.validate_args(test_args)
+            magma_access_gateway_installer.validate_args(test_args, self.TEST_INTERFACES_LIST)
 
     def test_given_invalid_ip_address_cli_argument_is_passed_when_validate_args_then_value_error_is_raised(  # noqa: E501
         self,
@@ -50,7 +56,7 @@ class TestAGWInstallerInit(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError):
-            magma_access_gateway_installer.validate_args(test_args)
+            magma_access_gateway_installer.validate_args(test_args, self.TEST_INTERFACES_LIST)
 
     def test_given_invalid_dns_ip_address_passed_when_validate_args_then_value_error_is_raised(
         self,
@@ -60,7 +66,7 @@ class TestAGWInstallerInit(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError):
-            magma_access_gateway_installer.validate_args(test_args)
+            magma_access_gateway_installer.validate_args(test_args, self.TEST_INTERFACES_LIST)
 
     def test_given_dns_flag_used_without_any_dns_ips_when_validate_args_then_value_error_is_raised(
         self,
@@ -68,4 +74,74 @@ class TestAGWInstallerInit(unittest.TestCase):
         test_args = Namespace(ip_address=None, gw_ip_address=None, dns=None)
 
         with self.assertRaises(ValueError):
-            magma_access_gateway_installer.validate_args(test_args)
+            magma_access_gateway_installer.validate_args(test_args, self.TEST_INTERFACES_LIST)
+
+    def test_given_only_sgi_cli_argument_is_passed_when_validate_args_then_value_error_is_raised(
+        self,
+    ):
+        test_args = Namespace(
+            ip_address=None,
+            gw_ip_address=None,
+            dns=self.DNS_LIST_WITH_VALID_ADDRESS,
+            sgi=self.VALID_TEST_SGi_INTERFACE_NAME,
+            s1=None,
+        )
+
+        with self.assertRaises(ValueError):
+            magma_access_gateway_installer.validate_args(test_args, self.TEST_INTERFACES_LIST)
+
+    def test_given_only_s1_cli_argument_is_passed_when_validate_args_then_value_error_is_raised(
+        self,
+    ):
+        test_args = Namespace(
+            ip_address=None,
+            gw_ip_address=None,
+            dns=self.DNS_LIST_WITH_VALID_ADDRESS,
+            sgi=None,
+            s1=self.VALID_TEST_S1_INTERFACE_NAME,
+        )
+
+        with self.assertRaises(ValueError):
+            magma_access_gateway_installer.validate_args(test_args, self.TEST_INTERFACES_LIST)
+
+    def test_given_invalid_sgi_cli_argument_is_passed_when_validate_args_then_value_error_is_raised(  # noqa: E501
+        self,
+    ):
+        test_args = Namespace(
+            ip_address=None,
+            gw_ip_address=None,
+            dns=self.DNS_LIST_WITH_VALID_ADDRESS,
+            sgi=self.INVALID_TEST_SGi_INTERFACE_NAME,
+            s1=self.VALID_TEST_S1_INTERFACE_NAME,
+        )
+
+        with self.assertRaises(ValueError):
+            magma_access_gateway_installer.validate_args(test_args, self.TEST_INTERFACES_LIST)
+
+    def test_given_invalid_s1_cli_argument_is_passed_when_validate_args_then_value_error_is_raised(
+        self,
+    ):
+        test_args = Namespace(
+            ip_address=None,
+            gw_ip_address=None,
+            dns=self.DNS_LIST_WITH_VALID_ADDRESS,
+            sgi=self.VALID_TEST_SGi_INTERFACE_NAME,
+            s1=self.INVALID_TEST_S1_INTERFACE_NAME,
+        )
+
+        with self.assertRaises(ValueError):
+            magma_access_gateway_installer.validate_args(test_args, self.TEST_INTERFACES_LIST)
+
+    def test_given_invalid_sgi_and_s1_cli_argument_is_passed_when_validate_args_then_value_error_is_raised(  # noqa: E501
+        self,
+    ):
+        test_args = Namespace(
+            ip_address=None,
+            gw_ip_address=None,
+            dns=self.DNS_LIST_WITH_VALID_ADDRESS,
+            sgi=self.INVALID_TEST_SGi_INTERFACE_NAME,
+            s1=self.INVALID_TEST_S1_INTERFACE_NAME,
+        )
+
+        with self.assertRaises(ValueError):
+            magma_access_gateway_installer.validate_args(test_args, self.TEST_INTERFACES_LIST)

--- a/tests/unit/test_magma_access_gateway_installer.py
+++ b/tests/unit/test_magma_access_gateway_installer.py
@@ -14,6 +14,7 @@ class TestAGWInstallerInit(unittest.TestCase):
     INVALID_TEST_IP_ADDRESS = "321.0.1.5/24"
     VALID_TEST_GW_IP_ADDRESS = "2.3.4.5"
     INVALID_TEST_GW_IP_ADDRESS = "321.3.4.5"
+    DNS_LIST_WITH_INVALID_ADDRESS = ["1.2.3.4", "321.3.4.5", "5.6.7.8"]
 
     def test_given_only_ip_address_cli_argument_is_passed_when_validate_args_then_value_error_is_raised(  # noqa: E501
         self,
@@ -47,6 +48,24 @@ class TestAGWInstallerInit(unittest.TestCase):
         test_args = Namespace(
             ip_address=self.INVALID_TEST_IP_ADDRESS, gw_ip_address=self.VALID_TEST_GW_IP_ADDRESS
         )
+
+        with self.assertRaises(ValueError):
+            magma_access_gateway_installer.validate_args(test_args)
+
+    def test_given_invalid_dns_ip_address_passed_when_validate_args_then_value_error_is_raised(
+        self,
+    ):
+        test_args = Namespace(
+            ip_address=None, gw_ip_address=None, dns=self.DNS_LIST_WITH_INVALID_ADDRESS
+        )
+
+        with self.assertRaises(ValueError):
+            magma_access_gateway_installer.validate_args(test_args)
+
+    def test_given_dns_flag_used_without_any_dns_ips_when_validate_args_then_value_error_is_raised(
+        self,
+    ):
+        test_args = Namespace(ip_address=None, gw_ip_address=None, dns=None)
 
         with self.assertRaises(ValueError):
             magma_access_gateway_installer.validate_args(test_args)


### PR DESCRIPTION
This PR introduces support for systems with multiple (more than 2) network interfaces. 
Using `--sgi` and `--s1` flags for `magma-access-gateway` installation command, operator will be able to specify which interface should serve which purpose. 