### PR TITLE
Telco 148 magma agw docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,16 +16,23 @@ The Snap in this repository is specifically developed for the
 **Building Magma AGW snap:**
 
 1. Install required software listed above
-2. From the repository's main directory execute:<br>
-   `snapcraft`<br>
+2. From the repository's main directory execute:
+
+   ```bash
+   snapcraft
+   ```
+   
    To see what's happening during Snap's building process, `-d` can be used along with above
    command.
 
 **Installing locally built Magma AGW snap:**
 
 1. Copy snap to AGW host machine.
-2. On AGW host machine, as `root` execute<br>
-   `snap install ${PATH_TO_THE_SNAP_FILE} --dangerous --classic`<br>
+2. On AGW host machine, as `root` execute:
+
+   ```bash
+   snap install <PATH_TO_THE_SNAP_FILE> --dangerous --classic
+   ```
    Since Snap has been built locally, `--dangerous` flag is required to deploy it. <br>
 
 To learn more about [magma-access-gateway](https://snapcraft.io/magma-access-gateway) deployment, 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,32 @@ The Snap in this repository is specifically developed for the
 
 ## Developing and testing
 
+**Required software:**
+
+- [Snapcraft](https://snapcraft.io/docs/snapcraft-overview)
+- [Multipass](https://multipass.run/)
+- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+
+**Building Magma AGW snap:**
+
+1. Install required software listed above
+2. From the repository's main directory execute:<br>
+   `snapcraft`<br>
+   To see what's happening during Snap's building process, `-d` can be used along with above
+   command.
+
+**Installing locally built Magma AGW snap:**
+
+1. Copy snap to AGW host machine.
+2. On AGW host machine, as `root` execute<br>
+   `snap install ${PATH_TO_THE_SNAP_FILE} --dangerous --classic`<br>
+   Since Snap has been built locally, `--dangerous` flag is required to deploy it. <br>
+
+To learn more about [magma-access-gateway](https://snapcraft.io/magma-access-gateway) deployment, 
+please see `README.md`.
+
+**Unit tests and static code analysis**
+
 Testing of the Snap is done using `tox`. To run tests, from this repository's main directory
 execute one of the following commands:
 
@@ -29,6 +55,6 @@ tox creates virtual environment for every tox environment defined in
 source .tox/unit/bin/activate
 ```
 
-## Integration tests
+**Integration tests**
 
 TBD

--- a/README.md
+++ b/README.md
@@ -29,21 +29,35 @@ This Snap is currently delivered as a [classic](https://snapcraft.io/docs/snap-c
 
 **Installing Magma AGW snap:**
 
-To install [magma-access-gateway](https://snapcraft.io/magma-access-gateway) execute:<br>
-`snap install magma-access-gateway --classic`<br>
+To install [magma-access-gateway](https://snapcraft.io/magma-access-gateway) execute:
+
+```bash
+snap install magma-access-gateway --classic
+```
+
 Once Snap is installed (it will be indicated by the `magma-access-gateway 1.6.0 installed`
-message printed to the console), start AGW deployment by executing:<br>
-`magma-access-gateway.install`<br>
+message printed to the console), start AGW deployment by executing:
+
+```bash
+magma-access-gateway.install
+```
+
 [magma-access-gateway](https://snapcraft.io/magma-access-gateway) installer exposes various
 deployment configuration parameters. To see the list of currently supported parameters along with
-their descriptions, execute:<br>
-`magma-access-gateway.install --help`
+their descriptions, execute:
+
+```bash
+magma-access-gateway.install --help
+```
 
 **Configuring Magma Access Gateway:**
 
-Magma Access Gateway can be configured by executing:<br>
-`magma-access-gateway.configure --domain <your domain> --root-ca-pem-path <path to Root CA PEM>`
-<br>
+Magma Access Gateway can be configured by executing:
+
+```bash
+magma-access-gateway.configure --domain <your domain> --root-ca-pem-path <path to Root CA PEM>
+```
+
 For more details about Magma Access Gateway configuration, visit 
 [Magma documentation](https://docs.magmacore.org/docs/next/lte/deploy_config_agw).
 
@@ -51,8 +65,11 @@ For more details about Magma Access Gateway configuration, visit
 
 Once Magma Access Gateway is installed and configured, post-installation checks can be run to 
 make sure everything has been configured correctly.<br>
-Post-installation checks can be executed by issuing:<br>
-`magma-access-gateway.post-install`
+Post-installation checks can be executed by issuing:
+
+```bash
+magma-access-gateway.post-install
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,40 +23,21 @@ This [Snap](https://snapcraft.io/) is part the
 
 ## Usage
 
-This Snap is not yet available in the official [Snap store](https://snapcraft.io/store), which
-means it needs to be built locally on user's hardware.<br>
+This Snap is available in the official [Snap store](https://snapcraft.io/store), as 
+[magma-access-gateway](https://snapcraft.io/magma-access-gateway). <br>
 This Snap is currently delivered as a [classic](https://snapcraft.io/docs/snap-confinement) Snap.
-
-**Required software:**
-
-- [Snapcraft](https://snapcraft.io/docs/snapcraft-overview)
-- [Multipass](https://multipass.run/)
-- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-
-**Building Magma AGW snap:**
-
-1. Install required software listed above
-2. Checkout [magma-access-gateway-snap](https://github.com/canonical/magma-access-gateway-snap)
-3. Inside checked out repository's main directory execute:<br>
-   `snapcraft`<br>
-   To see what's happening during Snap's building process, `-d` can be used along with above 
-   command.
 
 **Installing Magma AGW snap:**
 
-1. Copy snap to AGW host machine.
-2. On AGW host machine, as `root` execute<br>
-   `snap install ${PATH_TO_THE_SNAP_FILE} --dangerous --classic`<br>
-   Since Snap has been built locally, `--dangerous` flag is required to deploy it.
-3. Once Snap is installed (it will be indicated by the `magma-access-gateway 1.6.0 installed`
-   message printed to the console), start AGW deployment by executing:<br>
-   - `magma-access-gateway` - to deploy Magma AGW using DHCP configured SGi interface
-   - `magma-access-gateway --ip-address 1.1.1.1/24 --gw-ip-address 1.1.1.1` - to deploy Magma AGW
-     using statically configured SGi interface
-
-   Magma AGW uses **Google (8.8.8.8)** and **OpenDNS (208.67.222.222)** DNS servers by default. 
-   DNS servers can be configured by using `--dns` flag along with `magma-access-gateway` 
-   command. Custom DNS servers should be specified as space separated list of IP addresses.
+To install [magma-access-gateway](https://snapcraft.io/magma-access-gateway) execute:<br>
+`snap install magma-access-gateway --classic`<br>
+Once Snap is installed (it will be indicated by the `magma-access-gateway 1.6.0 installed`
+message printed to the console), start AGW deployment by executing:<br>
+`magma-access-gateway.install`<br>
+[magma-access-gateway](https://snapcraft.io/magma-access-gateway) installer exposes various
+deployment configuration parameters. To see the list of currently supported parameters along with
+their descriptions, execute:<br>
+`magma-access-gateway.install --help`
 
 **Configuring Magma Access Gateway:**
 

--- a/documentation/how-to-guides/deploy_magma_access_gateway.md
+++ b/documentation/how-to-guides/deploy_magma_access_gateway.md
@@ -1,0 +1,59 @@
+# How-to: Deploy Magma Access Gateway using magma-access-gateway snap
+
+The goal of this document is to guide the Operator through the process of deploying 
+Magma Access Gateway to a [compliant](#System requirements) piece of hardware using 
+[magma-access-gateway](https://snapcraft.io/magma-access-gateway) snap.<br>
+Unless specified otherwise, all actions in this guide are executed using `root` account.
+
+### System requirements
+
+- 64bit-X86 machine
+- Baremetal strongly recommended
+- Two ethernet interfaces (SGi and S1)
+- Internet connectivity from SGi interface
+- Ubuntu 20.04 LTS installed
+  ([Ubuntu installation guide](https://help.ubuntu.com/lts/installation-guide/amd64/index.html))
+
+## 1. Install magma-access-gateway snap
+
+From your Magma AGW host machine execute:
+
+```bash
+snap install magma-access-gateway --classic
+```
+
+## 2. Install magma-access-gateway
+
+From your Magma AGW host machine execute:
+
+```bash
+magma-access-gateway.install
+```
+
+[magma-access-gateway](https://snapcraft.io/magma-access-gateway) installer supports various 
+configuration options which can be used in the form of flags added to the main installation 
+command. To see the list of currently supported configuration options, execute:
+
+```bash
+magma-access-gateway.install --help
+```
+
+## 3. Configure magma-access-gateway
+
+- Get `rootCA.pem` certificate used during the Orc8r deployment.
+- Upload `rootCA.pem` to AGW host
+- From AGW host execute:
+
+```bash
+magma-access-gateway.configure --domain <Orc8r domain> --root-ca-pem-path <path to Root CA PEM>
+```
+
+## 4. Verify magma-access-gateway deployment
+
+Once Access Gateway has been successfully attached to the network, deployment can be verified 
+by running below command from the AGW host:
+
+```bash
+magma-access-gateway.post-install
+```
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ environment:
   PYTHONPATH: "$SNAP/lib/python3.8/site-packages"
 
 apps:
-  magma-access-gateway:
+  install:
     command: bin/install-agw
   configure:
     command: bin/configure-agw


### PR DESCRIPTION
This PR updates documentation of Magma AGW snap:
1. Adds first draft of AGW deployment how-to guide
2. Updates README and CONTRIBUTING docs to reflect the fact that [magma-access-gateway](https://snapcraft.io/magma-access-gateway) is now published to the SnapStore.