### PR TITLE
Fix: Use default Ubuntu box for building and publishing snap

### DIFF
--- a/.github/workflows/agw.branch_push.yml
+++ b/.github/workflows/agw.branch_push.yml
@@ -46,7 +46,7 @@ jobs:
 
   build-snap:
     name: Build Magma AGW snap
-    runs-on: telco-maas-host
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: snapcore/action-build@v1

--- a/.github/workflows/agw.main_push.yml
+++ b/.github/workflows/agw.main_push.yml
@@ -45,7 +45,7 @@ jobs:
 
   build-and-publish-snap:
     name: Build and publish Magma AGW snap
-    runs-on: telco-maas-host
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: snapcore/action-build@v1

--- a/.github/workflows/agw.pr_main.yml
+++ b/.github/workflows/agw.pr_main.yml
@@ -45,7 +45,7 @@ jobs:
 
   build-snap:
     name: Build Magma AGW snap
-    runs-on: telco-maas-host
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: snapcore/action-build@v1


### PR DESCRIPTION
- Temporarily replaces dedicated runner with default Ubuntu box to unblock publishing