### PR TITLE
Add support for DHCP on S1 interface

### DIFF
--- a/magma_access_gateway_installer/__init__.py
+++ b/magma_access_gateway_installer/__init__.py
@@ -91,7 +91,6 @@ def cli_arguments_parser(cli_arguments: list) -> argparse.Namespace:
         "--s1-ipv4-address",
         dest="s1_ipv4_address",
         required=False,
-        default="10.0.2.1/24",
         help="Statically allocated IPv4 address fot S1 interface. Example: 1.1.1.1/24.",
     )
     cli_options.add_argument(

--- a/magma_access_gateway_installer/resources/netplan_config.yaml.j2
+++ b/magma_access_gateway_installer/resources/netplan_config.yaml.j2
@@ -27,7 +27,7 @@ network:
         macaddress: {{ sgi_mac_address }}
       set-name: eth0
     eth1:
-    {%- if s1_ipv4_address != None+%}
+    {%- if s1_ipv4_address != None +%}
       dhcp4: false
       dhcp6: false
       addresses:

--- a/magma_access_gateway_installer/resources/netplan_config.yaml.j2
+++ b/magma_access_gateway_installer/resources/netplan_config.yaml.j2
@@ -27,6 +27,7 @@ network:
         macaddress: {{ sgi_mac_address }}
       set-name: eth0
     eth1:
+    {%- if s1_ipv4_address != None+%}
       dhcp4: false
       dhcp6: false
       addresses:
@@ -37,4 +38,8 @@ network:
       match:
         macaddress: {{ s1_mac_address }}
       set-name: eth1
+    {%- else +%}
+      dhcp4: true
+      dhcp6: true
+    {%- endif +%}
   version: 2

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -56,6 +56,8 @@ deps =
     pytest-operator
     types-setuptools
     types-toml
+setenv =
+    PYTHONPATH = ""
 commands =
     mypy -p {[vars]src_path}/magma_access_gateway_configurator -p {[vars]src_path}/magma_access_gateway_installer -p {[vars]src_path}/magma_access_gateway_post_install {posargs}
 


### PR DESCRIPTION
If no IPv4 address is specified for S1 interface, use DHCP. This will make this snap simpler to test in cloud environments.