### PR TITLE
Fix: Unsupported kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# VSCode settings
+.vscode/*
+
 # Rope project settings
 .ropeproject
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,13 @@ The Snap in this repository is specifically developed for the
 
 ## Developing and testing
 
-**Required software:**
+### Required software:
 
 - [Snapcraft](https://snapcraft.io/docs/snapcraft-overview)
 - [Multipass](https://multipass.run/)
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
-**Building Magma AGW snap:**
+### Building Magma AGW snap:
 
 1. Install required software listed above
 2. From the repository's main directory execute:
@@ -21,11 +21,11 @@ The Snap in this repository is specifically developed for the
    ```bash
    snapcraft
    ```
-   
-   To see what's happening during hte snap building process, `-d` can be used along with above
+
+   To see what's happening during the snap building process, `-d` can be used along with above
    command.
 
-**Installing locally built Magma AGW snap:**
+### Installing locally built Magma AGW snap:
 
 1. Copy snap to AGW host machine.
 2. On AGW host machine, as `root` execute:
@@ -34,7 +34,7 @@ The Snap in this repository is specifically developed for the
    snap install <PATH_TO_THE_SNAP_FILE> --dangerous --classic
    ```
 
-**Unit tests and static code analysis**
+### Unit tests and static code analysis
 
 Testing of the snap is done using `tox`. To run tests, from this repository's main directory
 execute one of the following commands:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ For more information on Magma please visit the [official website](https://magmac
 
 - Ubuntu 20.04 LTS
   ([Ubuntu installation guide](https://help.ubuntu.com/lts/installation-guide/amd64/index.html))
+- Linux Kernel version `5.4`
+
+> :warning: Some clouds like AWS use newer kernel versions by default. If you want to downgrade your kernel, please refer to the following [guide](https://discourse.ubuntu.com/t/how-to-downgrade-the-kernel-on-ubuntu-20-04-to-the-5-4-lts-version/26459).
 
 
 ## Usage

--- a/magma_access_gateway_installer/agw_installation_errors.py
+++ b/magma_access_gateway_installer/agw_installation_errors.py
@@ -28,15 +28,17 @@ class UnsupportedOSError(AGWInstallationError):
     def __init__(self):
         super().__init__("Invalid OS. Only Ubuntu 20.04 is supported.")
 
-        
+
 class UnsupportedKernelVersionError(AGWInstallationError):
     """Exception raised when unsupported kernel version is detected."""
 
     def __init__(self):
-        self._message = """Invalid Kernel Version. Only 5.4.0 is supported. For downgrading kernel version, please refer to
-        https://discourse.ubuntu.com/t/how-to-downgrade-the-kernel-on-ubuntu-20-04-to-the-5-4-lts-version/26459"""
+        self._message = (
+            "Invalid Kernel Version. Only 5.4.0 is supported. For downgrading kernel version, please refer to:\n"  # noqa E501, W505
+            "https://discourse.ubuntu.com/t/how-to-downgrade-the-kernel-on-ubuntu-20-04-to-the-5-4-lts-version/26459"  # noqa E501, W505
+        )
         super().__init__(self._message)
-        
+
 
 class InvalidNumberOfInterfacesError(AGWInstallationError):
     """Exception raised if number of available network interfaces is different from expected."""

--- a/magma_access_gateway_installer/agw_installation_errors.py
+++ b/magma_access_gateway_installer/agw_installation_errors.py
@@ -28,6 +28,15 @@ class UnsupportedOSError(AGWInstallationError):
     def __init__(self):
         super().__init__("Invalid OS. Only Ubuntu 20.04 is supported.")
 
+        
+class UnsupportedKernelVersionError(AGWInstallationError):
+    """Exception raised when unsupported kernel version is detected."""
+
+    def __init__(self):
+        self._message = """Invalid Kernel Version. Only 5.4.0 is supported. For downgrading kernel version, please refer to
+        https://discourse.ubuntu.com/t/how-to-downgrade-the-kernel-on-ubuntu-20-04-to-the-5-4-lts-version/26459"""
+        super().__init__(self._message)
+        
 
 class InvalidNumberOfInterfacesError(AGWInstallationError):
     """Exception raised if number of available network interfaces is different from expected."""

--- a/magma_access_gateway_installer/agw_preinstall.py
+++ b/magma_access_gateway_installer/agw_preinstall.py
@@ -8,8 +8,8 @@ from subprocess import check_call, check_output
 from .agw_installation_errors import (
     InvalidNumberOfInterfacesError,
     InvalidUserError,
-    UnsupportedOSError,
     UnsupportedKernelVersionError,
+    UnsupportedOSError,
 )
 
 logger = logging.getLogger("magma_access_gateway_installer")
@@ -74,10 +74,9 @@ class AGWInstallerPreinstall:
     def _required_amount_of_network_interfaces_is_available(self) -> bool:
         """Checks whether required amount of network interfaces has been attached."""
         return len(self.network_interfaces) >= self.REQUIRED_NUMBER_OF_NICS
-    
+
     @property
     def _kernel_version_is_supported(self) -> bool:
         """Checks whether kernel version is supported."""
         kernel_version = check_output(["uname", "-r"]).decode("utf-8").rstrip()
         return self.SUPPORTED_KERNEL_VERSION in kernel_version
-

--- a/magma_access_gateway_installer/agw_preinstall.py
+++ b/magma_access_gateway_installer/agw_preinstall.py
@@ -9,6 +9,7 @@ from .agw_installation_errors import (
     InvalidNumberOfInterfacesError,
     InvalidUserError,
     UnsupportedOSError,
+    UnsupportedKernelVersionError,
 )
 
 logger = logging.getLogger("magma_access_gateway_installer")
@@ -18,6 +19,7 @@ class AGWInstallerPreinstall:
 
     REQUIRED_NUMBER_OF_NICS = 2
     REQUIRED_SYSTEM_PACKAGES = ["ifupdown", "net-tools", "sudo"]
+    SUPPORTED_KERNEL_VERSION = "5.4.0"
 
     def __init__(self, network_interfaces: list):
         self.network_interfaces = network_interfaces
@@ -37,6 +39,8 @@ class AGWInstallerPreinstall:
             raise InvalidUserError()
         elif not self._ubuntu_is_installed:
             raise UnsupportedOSError()
+        elif not self._kernel_version_is_supported:
+            raise UnsupportedKernelVersionError()
         elif not self._required_amount_of_network_interfaces_is_available:
             raise InvalidNumberOfInterfacesError()
         else:
@@ -70,3 +74,10 @@ class AGWInstallerPreinstall:
     def _required_amount_of_network_interfaces_is_available(self) -> bool:
         """Checks whether required amount of network interfaces has been attached."""
         return len(self.network_interfaces) >= self.REQUIRED_NUMBER_OF_NICS
+    
+    @property
+    def _kernel_version_is_supported(self) -> bool:
+        """Checks whether kernel version is supported."""
+        kernel_version = check_output(["uname", "-r"]).decode("utf-8").rstrip()
+        return self.SUPPORTED_KERNEL_VERSION in kernel_version
+

--- a/magma_access_gateway_post_install/__init__.py
+++ b/magma_access_gateway_post_install/__init__.py
@@ -32,6 +32,7 @@ def main():
         agw_post_install_checks = AGWPostInstallChecks()
         agw_post_install_checks.check_whether_required_interfaces_are_configured()
         agw_post_install_checks.check_eth0_internet_connectivity()
+        agw_post_install_checks.check_ovs_has_not_unsupported_gpt_error()
         agw_post_install_checks.check_whether_required_services_are_running()
         agw_post_install_checks.check_whether_required_packages_are_installed()
         agw_post_install_checks.check_whether_root_certificate_exists()

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -5,7 +5,7 @@
 import logging
 import os
 import time
-from subprocess import DEVNULL, call
+from subprocess import DEVNULL, call, check_output
 
 import yaml
 from ping3 import ping  # type: ignore[import]
@@ -86,6 +86,23 @@ class AGWPostInstallChecks:
                 "  - Invalid configuration in /etc/netplan/99-magma-config.yaml.\n"
                 "  - Interface not being connected to the network.\n"
                 "  - Problem with Open vSwitch installation."
+            )
+
+    @staticmethod
+    def check_ovs_has_not_unsupported_gpt_error():
+        """Checks whether ovs has unsupported gtp error.
+
+        :raises:
+            AGWConfigurationError: if OVS has any gtp error
+        """
+        logger.info("Checking whether OVS has unsupported gtp error")
+        error = b'error: "could not add network device'
+
+        if (ovs_show_result := check_output(["sudo", "ovs-vsctl", "show"])).decode(
+            "utf-8"
+        ).rstrip() and error in ovs_show_result:  # noqa: E501  # noqa: W503
+            raise AGWConfigurationError(
+                "OVS unsupported gtp error. Please check the following link for more "
             )
 
     @staticmethod

--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -102,7 +102,8 @@ class AGWPostInstallChecks:
             "utf-8"
         ).rstrip() and error in ovs_show_result:  # noqa: E501  # noqa: W503
             raise AGWConfigurationError(
-                "OVS unsupported gtp error. Please check the following link for more "
+                "OVS does not support gtp. Make sure your kernel is 5.4. For downgrading your kernel, please refer to:"  # noqa E501, W505
+                "https://discourse.ubuntu.com/t/how-to-downgrade-the-kernel-on-ubuntu-20-04-to-the-5-4-lts-version/26459"  # noqa E501, W505
             )
 
     @staticmethod

--- a/tests/unit/test_magma_access_gateway_installer/test_agw_preinstall.py
+++ b/tests/unit/test_magma_access_gateway_installer/test_agw_preinstall.py
@@ -9,6 +9,7 @@ from magma_access_gateway_installer.agw_installation_errors import (
     InvalidNumberOfInterfacesError,
     InvalidUserError,
     UnsupportedOSError,
+    UnsupportedKernelVersionError,
 )
 from magma_access_gateway_installer.agw_preinstall import AGWInstallerPreinstall
 
@@ -38,6 +39,7 @@ PRETTY_NAME="Ubuntu 20.04.4 LTS"
 VERSION_ID="20.04"
 """
     INVALID_TEST_NETWORK_INTERFACES = ["test1"]
+    UNSUPPORTED_KERNEL_VERSION = "5.15.0-1045-aws"
 
     def setUp(self) -> None:
         self.agw_preinstall = AGWInstallerPreinstall(self.TEST_NETWORK_INTERFACES)
@@ -80,6 +82,16 @@ VERSION_ID="20.04"
         self, _, __
     ):
         with self.assertRaises(UnsupportedOSError):
+            self.agw_preinstall.preinstall_checks()
+
+    @patch(
+        "magma_access_gateway_installer.agw_preinstall.check_output",
+        return_value=UNSUPPORTED_KERNEL_VERSION,
+    )
+    def test_given_kernel_version_is_not_supported_when_preinstall_checks_then_unsupported_kernel_version_error_is_raised(  # noqa: E501
+        self
+    ):
+        with self.assertRaises(UnsupportedKernelVersionError):
             self.agw_preinstall.preinstall_checks()
 
     @patch(

--- a/tests/unit/test_magma_access_gateway_installer/test_agw_preinstall.py
+++ b/tests/unit/test_magma_access_gateway_installer/test_agw_preinstall.py
@@ -8,8 +8,8 @@ from unittest.mock import PropertyMock, call, mock_open, patch
 from magma_access_gateway_installer.agw_installation_errors import (
     InvalidNumberOfInterfacesError,
     InvalidUserError,
-    UnsupportedOSError,
     UnsupportedKernelVersionError,
+    UnsupportedOSError,
 )
 from magma_access_gateway_installer.agw_preinstall import AGWInstallerPreinstall
 
@@ -85,15 +85,23 @@ VERSION_ID="20.04"
             self.agw_preinstall.preinstall_checks()
 
     @patch(
-        "magma_access_gateway_installer.agw_preinstall.check_output",
-        return_value=UNSUPPORTED_KERNEL_VERSION,
+        "magma_access_gateway_installer.agw_preinstall.AGWInstallerPreinstall._user_is_root",
+        new_callable=PropertyMock,
     )
-    def test_given_kernel_version_is_not_supported_when_preinstall_checks_then_unsupported_kernel_version_error_is_raised(  # noqa: E501
-        self
+    @patch(
+        "magma_access_gateway_installer.agw_preinstall.check_output",
+        return_value=UNSUPPORTED_KERNEL_VERSION.encode("utf-8"),
+    )
+    def test_given_not_supported_kernel_version_when_preinstall_checks_then_unsupported_kernel_version_error_is_raised(  # noqa: E501
+        self, _, __
     ):
         with self.assertRaises(UnsupportedKernelVersionError):
             self.agw_preinstall.preinstall_checks()
 
+    @patch(
+        "magma_access_gateway_installer.agw_preinstall.AGWInstallerPreinstall._kernel_version_is_supported",  # noqa: E501
+        new_callable=PropertyMock,
+    )
     @patch(
         "magma_access_gateway_installer.agw_preinstall.AGWInstallerPreinstall._user_is_root",  # noqa: E501
         new_callable=PropertyMock,
@@ -103,7 +111,7 @@ VERSION_ID="20.04"
         new_callable=PropertyMock,
     )
     def test_given_insufficient_number_of_network_interfaces_when_preinstall_checks_then_invalid_number_of_interfaces_error_is_raised(  # noqa: E501
-        self, _, __
+        self, _, __, ___
     ):
         agw_preinstall = AGWInstallerPreinstall(self.INVALID_TEST_NETWORK_INTERFACES)
         with self.assertRaises(InvalidNumberOfInterfacesError):
@@ -121,6 +129,10 @@ VERSION_ID="20.04"
 
         mock_check_call.assert_has_calls(expected_apt_calls)
 
+    @patch(
+        "magma_access_gateway_installer.agw_preinstall.AGWInstallerPreinstall._kernel_version_is_supported",  # noqa: E501
+        new_callable=PropertyMock,
+    )
     @patch("magma_access_gateway_installer.agw_preinstall.logger.info")
     @patch(
         "magma_access_gateway_installer.agw_preinstall.open",
@@ -132,7 +144,7 @@ VERSION_ID="20.04"
         return_value=VALID_TEST_USER,
     )
     def test_given_system_meets_installation_requirements_when_preinstall_checks_then_preinstall_check_are_completed_without_errors(  # noqa: E501
-        self, _, __, mocked_logger
+        self, _, __, mocked_logger, ___
     ):
         self.agw_preinstall.preinstall_checks()
 


### PR DESCRIPTION
Addresses the issue of `gtp_br0` interface not working due to Linux kernel incompatibility with Open vSwitch, thus blocking traffic between UEs and the AGW.

Solves the issue by adding:
- Kernel version pre-install check. When an unsupported version is found we prevent users to move forward.
- OVS post-install check for making sure there are no OVS related errors in `ovs-vsctl show` output.

The tested kernel version recommended by the Magma community is `5.4`