### PR TITLE
Fix: Sets Ubuntu20.04 default version for CI

### DIFF
--- a/.github/workflows/agw.branch_push.yml
+++ b/.github/workflows/agw.branch_push.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   agw-lint-report:
     name: Lint report
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox
@@ -20,7 +20,7 @@ jobs:
 
   agw-static-analysis:
     name: Static analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox
@@ -34,7 +34,7 @@ jobs:
 
   agw-unit-tests-with-coverage:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox
@@ -48,7 +48,7 @@ jobs:
 
   build-snap:
     name: Build Magma AGW snap
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: snapcore/action-build@v1

--- a/.github/workflows/agw.main_push.yml
+++ b/.github/workflows/agw.main_push.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   agw-lint-report:
     name: Lint report
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox
@@ -19,7 +19,7 @@ jobs:
 
   agw-static-analysis:
     name: Static analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox
@@ -33,7 +33,7 @@ jobs:
 
   agw-unit-tests-with-coverage:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox
@@ -47,7 +47,7 @@ jobs:
 
   build-and-publish-snap:
     name: Build and publish Magma AGW snap
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: snapcore/action-build@v1

--- a/.github/workflows/agw.pr_main.yml
+++ b/.github/workflows/agw.pr_main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   agw-lint-report:
     name: Lint report
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox
@@ -19,7 +19,7 @@ jobs:
 
   agw-static-analysis:
     name: Static analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox
@@ -33,7 +33,7 @@ jobs:
 
   agw-unit-tests-with-coverage:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install tox
@@ -47,7 +47,7 @@ jobs:
 
   build-snap:
     name: Build Magma AGW snap
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: snapcore/action-build@v1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ the AGW implements an evolved packet core (EPC), and a combination of an AAA and
 with existing, unmodified commercial radio hardware.<br>
 For more information on Magma please visit the [official website](https://magmacore.org/).
 
-> **WARNING:** Installing this snap will affect your computer's networking configuration.
+> :warning: Installing this snap will affect your computer's networking configuration.
 > Make sure it is installed on designated hardware (personal computers are strongly discouraged).
 
 ### System requirements


### PR DESCRIPTION
- Changes `Ubuntu-latest` to `20.04` in the CI workflows to match requirements.