### PR TITLE
Fix: Disable cloudinit network management

### DIFF
--- a/magma_access_gateway_installer/__init__.py
+++ b/magma_access_gateway_installer/__init__.py
@@ -219,6 +219,7 @@ def validate_s1_addressing(s1_ip_address: str):
 def configure_network(args: argparse.Namespace):
     network_config = generate_network_config(args)
     network_configurator = AGWInstallerNetworkConfigurator(network_config)
+    network_configurator.disable_cloudinit_network_management()
     network_configurator.configure_dns()
     network_configurator.configure_network_interfaces()
     network_configurator.apply_netplan_configuration()

--- a/magma_access_gateway_installer/agw_network_configurator.py
+++ b/magma_access_gateway_installer/agw_network_configurator.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+import pathlib
 from subprocess import check_call
 
 from jinja2 import Environment, FileSystemLoader, Template
@@ -16,6 +17,7 @@ class AGWInstallerNetworkConfigurator:
     MAGMA_NETPLAN_CONFIG_FILE = "/etc/netplan/99-magma-config.yaml"
     MAGMA_NETPLAN_CONFIG_TEMPLATE = "netplan_config.yaml.j2"
     ETC_SYSTEMD_RESOLVED_CONF_PATH = "/etc/systemd/resolved.conf"
+    CLOUDINIT_CONFIG_DIR = "/etc/cloud/cloud.cfg.d"
 
     def __init__(
         self,
@@ -31,6 +33,13 @@ class AGWInstallerNetworkConfigurator:
     def configure_network_interfaces(self):
         """Creates and applies network configuration required by Magma AGW."""
         self._create_netplan_config()
+
+    def disable_cloudinit_network_management(self):
+        """Disable network management by cloudinit."""
+        cloudinit_dir = pathlib.Path(self.CLOUDINIT_CONFIG_DIR)
+        cloudinit_dir.mkdir(parents=True, exist_ok=True)
+        disable_network_conf = cloudinit_dir / "99-disable-network-config.cfg"
+        disable_network_conf.write_text("network: {config: disabled}")
 
     @staticmethod
     def apply_netplan_configuration():


### PR DESCRIPTION
# Description

Disables cloudinit network management that can conflict with the applied netplan. On Openstack, having cloudinit network management enabled will rename the interfaces back to their original names.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
