### PR TITLE
Fixing RC from failed post-install

### DIFF
--- a/magma_access_gateway_post_install/__init__.py
+++ b/magma_access_gateway_post_install/__init__.py
@@ -40,4 +40,4 @@ def main():
         agw_post_install_checks.check_connectivity_with_orc8r()
         logger.info("Magma AGW post-installation checks finished successfully.")
     except PostInstallError:
-        return
+        sys.exit(1)

--- a/tests/unit/test_magma_access_gateway_post_install/test_agw_post_install.py
+++ b/tests/unit/test_magma_access_gateway_post_install/test_agw_post_install.py
@@ -5,6 +5,7 @@
 import unittest
 from unittest.mock import Mock, PropertyMock, mock_open, patch
 
+from magma_access_gateway_post_install import main as access_gateway_post_install_main
 from magma_access_gateway_post_install.agw_post_install import (
     AGWConfigurationError,
     AGWControlProxyConfigFileMissingError,
@@ -244,6 +245,16 @@ class TestAGWPostInstallChecks(unittest.TestCase):
 
         with self.assertRaises(Orc8rConnectivityError):
             self.agw_post_install.check_connectivity_with_orc8r()
+
+    @patch("magma_access_gateway_post_install.agw_post_install.journal.Reader", new_callable=Mock)
+    def test_given_journal_not_containing_cloud_checkin_logs_when_post_install_exit_then_script_rc_is_1(  # noqa: E501
+        self, mocked_journal_reader
+    ):
+        mocked_journal_reader.return_value = MockedJournalReader(False)
+
+        with self.assertRaises(SystemExit) as se:
+            access_gateway_post_install_main()
+        self.assertEqual(se.exception.code, 1)
 
 
 class MockedJournalReader:


### PR DESCRIPTION
# Description

Fixes the RC of the post-install command, so that it returns `1` in case of failure.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
