### PR TITLE
Rmoving sentry_url_python from mandatory keys

### DIFF
--- a/magma_access_gateway_post_install/agw_post_install.py
+++ b/magma_access_gateway_post_install/agw_post_install.py
@@ -60,7 +60,6 @@ class AGWPostInstallChecks:
         "rootca_cert",
         "fluentd_address",
         "fluentd_port",
-        "sentry_url_python",
     ]
     GOT_HEARTBEAT_MSG = "[SyncRPC] Got heartBeat from cloud"
     ORC8R_CHECKIN_SUCCESSFUL_MSG = "Checkin Successful! Successfully sent states to the cloud!"


### PR DESCRIPTION
# Description

Removes `sentry_url_python` from the list of mandatory keys inside the `control_proxy.yaml`, because it's not really mandatory.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
