### PR TITLE
Fixing network configuration for AWS

### DIFF
--- a/magma_access_gateway_installer/agw_network_configurator.py
+++ b/magma_access_gateway_installer/agw_network_configurator.py
@@ -53,12 +53,16 @@ class AGWInstallerNetworkConfigurator:
         with open(self.MAGMA_NETPLAN_CONFIG_FILE, "w") as magma_netplan_config:
             magma_netplan_config.write(
                 netplan_config_template.render(
-                    sgi_ipv4_address=self.network_config["sgi_ipv4_address"],
+                    sgi_ipv4_address_cidr=self.network_config["sgi_ipv4_address_cidr"],
                     sgi_ipv4_gateway=self.network_config["sgi_ipv4_gateway"],
-                    sgi_ipv6_address=self.network_config["sgi_ipv6_address"],
+                    sgi_ipv6_address_cidr=self.network_config["sgi_ipv6_address_cidr"],
                     sgi_ipv6_gateway=self.network_config["sgi_ipv6_gateway"],
+                    s1_ipv4_address_cidr=self.network_config["s1_ipv4_address_cidr"],
                     s1_ipv4_address=self.network_config["s1_ipv4_address"],
+                    s1_ipv4_gateway=self.network_config["s1_ipv4_gateway"],
+                    s1_ipv6_address_cidr=self.network_config["s1_ipv6_address_cidr"],
                     s1_ipv6_address=self.network_config["s1_ipv6_address"],
+                    s1_ipv6_gateway=self.network_config["s1_ipv6_gateway"],
                     sgi_mac_address=self.network_config["sgi_mac_address"],
                     s1_mac_address=self.network_config["s1_mac_address"],
                 ),

--- a/magma_access_gateway_installer/resources/netplan_config.yaml.j2
+++ b/magma_access_gateway_installer/resources/netplan_config.yaml.j2
@@ -2,18 +2,18 @@
 network:
   ethernets:
     eth0:
-    {%- if sgi_ipv4_address != None +%}
+    {%- if sgi_ipv4_address_cidr != None +%}
       dhcp4: false
       dhcp6: false
       addresses:
-        - {{ sgi_ipv4_address }}
-      {%- if sgi_ipv6_address != None +%}
-        - {{ sgi_ipv6_address }}
+        - {{ sgi_ipv4_address_cidr }}
+      {%- if sgi_ipv6_address_cidr != None +%}
+        - {{ sgi_ipv6_address_cidr }}
       {%- endif +%}
       routes:
         - to: default
           via: {{ sgi_ipv4_gateway }}
-        {%- if sgi_ipv6_address != None +%}
+        {%- if sgi_ipv6_address_cidr != None +%}
           metric: 200
         - to: default
           via: {{ sgi_ipv6_gateway }}
@@ -27,13 +27,39 @@ network:
         macaddress: {{ sgi_mac_address }}
       set-name: eth0
     eth1:
-    {%- if s1_ipv4_address != None +%}
+    {%- if s1_ipv4_address_cidr != None +%}
       dhcp4: false
       dhcp6: false
       addresses:
-        - {{ s1_ipv4_address }}
-      {%- if s1_ipv6_address != None +%}
-        - {{ s1_ipv6_address }}
+        - {{ s1_ipv4_address_cidr }}
+        {%- if s1_ipv6_address_cidr != None +%}
+        - {{ s1_ipv6_address_cidr }}
+        {%- endif +%}
+      {%- if s1_ipv4_gateway != None +%}
+      routes:
+        - to: 0.0.0.0/0
+          via: {{ s1_ipv4_gateway }}
+          table: 1000
+        - to: {{ s1_ipv4_address }}
+          via: 0.0.0.0
+          scope: link
+          table: 1000
+        {%- if s1_ipv6_gateway != None +%}
+        - to: ::/0
+          via: {{ s1_ipv6_gateway }}
+          table: 1001
+        - to: {{ s1_ipv6_address }}
+          via: ::/0
+          scope: link
+          table: 1001
+        {%- endif +%}
+      routing-policy:
+        - from: {{ s1_ipv4_address }}
+          table: 1000
+        {%- if s1_ipv6_gateway != None +%}
+        - from: {{ s1_ipv6_address }}
+          table: 1001
+        {%- endif +%}
       {%- endif +%}
     {%- else +%}
       dhcp4: true

--- a/tests/unit/test_magma_access_gateway_installer/test_agw_network_configurator.py
+++ b/tests/unit/test_magma_access_gateway_installer/test_agw_network_configurator.py
@@ -15,44 +15,47 @@ class TestAGWInstallerNetworkConfigurator(unittest.TestCase):
     DNS_TEST_NETWORK_CONFIG = {
         "dns_address": "1.2.3.4 5.6.7.8",
     }
-    EMPTY_NETWORK_CONFIG = {
-        "sgi_ipv4_address": None,
-        "sgi_ipv4_gateway": None,
-        "sgi_ipv6_address": None,
-        "sgi_ipv6_gateway": None,
-        "sgi_mac_address": None,
-        "s1_mac_address": None,
-        "dns_address": None,
-    }
     DHCP_BASED_NETWORK_CONFIG = {
-        "sgi_ipv4_address": None,
+        "sgi_ipv4_address_cidr": None,
         "sgi_ipv4_gateway": None,
-        "sgi_ipv6_address": None,
+        "sgi_ipv6_address_cidr": None,
         "sgi_ipv6_gateway": None,
-        "s1_ipv4_address": "10.9.8.7/24",
+        "s1_ipv4_address_cidr": None,
+        "s1_ipv4_address": None,
+        "s1_ipv4_gateway": None,
+        "s1_ipv6_address_cidr": None,
         "s1_ipv6_address": None,
+        "s1_ipv6_gateway": None,
         "sgi_mac_address": "aa:bb:cc:dd:ee:ff",
         "s1_mac_address": "ff:ee:dd:cc:bb:aa",
         "dns_address": None,
     }
     STATIC_IPv4_NETWORK_CONFIG = {
-        "sgi_ipv4_address": "1.2.3.4/24",
+        "sgi_ipv4_address_cidr": "1.2.3.4/24",
         "sgi_ipv4_gateway": "5.6.7.8",
-        "sgi_ipv6_address": None,
+        "sgi_ipv6_address_cidr": None,
         "sgi_ipv6_gateway": None,
-        "s1_ipv4_address": "10.9.8.7/24",
+        "s1_ipv4_address_cidr": "10.9.8.7/24",
+        "s1_ipv4_address": "10.9.8.7",
+        "s1_ipv4_gateway": None,
+        "s1_ipv6_address_cidr": None,
         "s1_ipv6_address": None,
+        "s1_ipv6_gateway": None,
         "sgi_mac_address": "aa:bb:cc:dd:ee:ff",
         "s1_mac_address": "ff:ee:dd:cc:bb:aa",
         "dns_address": None,
     }
     STATIC_DUALSTACK_NETWORK_CONFIG = {
-        "sgi_ipv4_address": "1.2.3.4/24",
+        "sgi_ipv4_address_cidr": "1.2.3.4/24",
         "sgi_ipv4_gateway": "5.6.7.8",
-        "sgi_ipv6_address": "aaaa:bbbb:cccc:dddd:1:2:3:4/64",
+        "sgi_ipv6_address_cidr": "aaaa:bbbb:cccc:dddd:1:2:3:4/64",
         "sgi_ipv6_gateway": "dddd:cccc:bbbb:aaaa:5:6:7:8",
-        "s1_ipv4_address": "10.9.8.7/24",
-        "s1_ipv6_address": "aaaa:bbbb:cccc:dddd:10:9:8:7/64",
+        "s1_ipv4_address_cidr": "10.9.8.7/24",
+        "s1_ipv4_address": "10.9.8.7",
+        "s1_ipv4_gateway": None,
+        "s1_ipv6_address_cidr": "aaaa:bbbb:cccc:dddd:10:9:8:7/64",
+        "s1_ipv6_address": "aaaa:bbbb:cccc:dddd:10:9:8:7",
+        "s1_ipv6_gateway": None,
         "sgi_mac_address": "aa:bb:cc:dd:ee:ff",
         "s1_mac_address": "ff:ee:dd:cc:bb:aa",
         "dns_address": None,
@@ -101,10 +104,8 @@ network:
         macaddress: aa:bb:cc:dd:ee:ff
       set-name: eth0
     eth1:
-      dhcp4: false
-      dhcp6: false
-      addresses:
-        - 10.9.8.7/24
+      dhcp4: true
+      dhcp6: true
       match:
         macaddress: ff:ee:dd:cc:bb:aa
       set-name: eth1

--- a/tests/unit/test_magma_access_gateway_installer/test_magma_access_gateway_installer.py
+++ b/tests/unit/test_magma_access_gateway_installer/test_magma_access_gateway_installer.py
@@ -20,8 +20,10 @@ class TestAGWInstallerInit(unittest.TestCase):
     VALID_TEST_SGi_IPv6_GATEWAY = "fd9c:0175:3d65:cfbd:4:3:2:1"
     VALID_TEST_S1_IPv4_ADDRESS = "10.9.8.7/24"
     INVALID_TEST_S1_IPv4_ADDRESS = "100.900.800.700/24"
+    VALID_TEST_S1_IPv4_GATEWAY = "12.13.14.15"
     VALID_TEST_S1_IPv6_ADDRESS = "fd9c:0175:3d65:cfbd:10:9:8:7/64"
     INVALID_TEST_S1_IPv6_ADDRESS = "fd9c:0175:3d65:cfbd:10000:90000:80000:70000/64"
+    VALID_TEST_S1_IPv6_GATEWAY = "fd9c:0175:3d65:cfbd:12:13:14:15"
     DNS_LIST_WITH_VALID_ADDRESS = ["1.2.3.4", "5.6.7.8"]
     DNS_LIST_WITH_INVALID_ADDRESS = ["1.2.3.4", "321.3.4.5", "5.6.7.8"]
     TEST_INTERFACES_LIST = ["lo", "bear", "rabbit", "eagle", "moose"]
@@ -37,7 +39,9 @@ class TestAGWInstallerInit(unittest.TestCase):
         sgi_ipv6_address=VALID_TEST_SGi_IPv6_ADDRESS,
         sgi_ipv6_gateway=VALID_TEST_SGi_IPv6_GATEWAY,
         s1_ipv4_address=VALID_TEST_S1_IPv4_ADDRESS,
+        s1_ipv4_gateway=VALID_TEST_S1_IPv4_GATEWAY,
         s1_ipv6_address=VALID_TEST_S1_IPv6_ADDRESS,
+        s1_ipv6_gateway=VALID_TEST_S1_IPv6_GATEWAY,
         dns=DNS_LIST_WITH_VALID_ADDRESS,
         sgi=VALID_TEST_SGi_INTERFACE_NAME,
         s1=VALID_TEST_S1_INTERFACE_NAME,
@@ -60,7 +64,9 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=None,
             sgi_ipv6_gateway=None,
             s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
         )
 
         with self.assertRaises(magma_access_gateway_installer.ArgumentError):
@@ -76,7 +82,9 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=None,
             sgi_ipv6_gateway=None,
             s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
         )
 
         with self.assertRaises(magma_access_gateway_installer.ArgumentError):
@@ -92,7 +100,9 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=None,
             sgi_ipv6_gateway=None,
             s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
         )
 
         with self.assertRaises(magma_access_gateway_installer.ArgumentError):
@@ -108,7 +118,9 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=None,
             sgi_ipv6_gateway=None,
             s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
         )
 
         with self.assertRaises(magma_access_gateway_installer.ArgumentError):
@@ -124,7 +136,9 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=None,
             sgi_ipv6_gateway=None,
             s1_ipv4_address=self.INVALID_TEST_S1_IPv4_ADDRESS,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
         )
 
         with self.assertRaises(magma_access_gateway_installer.ArgumentError):
@@ -140,7 +154,9 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=None,
             sgi_ipv6_gateway=None,
             s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=self.INVALID_TEST_S1_IPv6_ADDRESS,
+            s1_ipv6_gateway=None,
         )
 
         with self.assertRaises(magma_access_gateway_installer.ArgumentError):
@@ -156,7 +172,45 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=self.VALID_TEST_SGi_IPv6_ADDRESS,
             sgi_ipv6_gateway=self.VALID_TEST_SGi_IPv6_GATEWAY,
             s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
+        )
+
+        with self.assertRaises(magma_access_gateway_installer.ArgumentError):
+            magma_access_gateway_installer.validate_args(test_args)
+
+    @patch("magma_access_gateway_installer.netifaces.interfaces", MagicMock())
+    def test_given_s1_ipv4_gateway_without_s1_ipv4_addresses_when_validate_args_then_value_error_is_raise(  # noqa: E501
+        self,
+    ):
+        test_args = Namespace(
+            sgi_ipv4_address=None,
+            sgi_ipv4_gateway=None,
+            sgi_ipv6_address=None,
+            sgi_ipv6_gateway=None,
+            s1_ipv4_address=None,
+            s1_ipv4_gateway=self.VALID_TEST_S1_IPv4_GATEWAY,
+            s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
+        )
+
+        with self.assertRaises(magma_access_gateway_installer.ArgumentError):
+            magma_access_gateway_installer.validate_args(test_args)
+
+    @patch("magma_access_gateway_installer.netifaces.interfaces", MagicMock())
+    def test_given_s1_ipv6_gateway_without_s1_ipv6_addresses_when_validate_args_then_value_error_is_raise(  # noqa: E501
+        self,
+    ):
+        test_args = Namespace(
+            sgi_ipv4_address=None,
+            sgi_ipv4_gateway=None,
+            sgi_ipv6_address=None,
+            sgi_ipv6_gateway=None,
+            s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
+            s1_ipv6_address=None,
+            s1_ipv6_gateway=self.VALID_TEST_S1_IPv6_GATEWAY,
         )
 
         with self.assertRaises(magma_access_gateway_installer.ArgumentError):
@@ -172,7 +226,9 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=None,
             sgi_ipv6_gateway=None,
             s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
             dns=self.DNS_LIST_WITH_INVALID_ADDRESS,
         )
 
@@ -189,7 +245,9 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=None,
             sgi_ipv6_gateway=None,
             s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
             dns=self.DNS_LIST_WITH_VALID_ADDRESS,
             sgi=self.INVALID_TEST_SGi_INTERFACE_NAME,
             s1=self.VALID_TEST_S1_INTERFACE_NAME,
@@ -208,7 +266,9 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=None,
             sgi_ipv6_gateway=None,
             s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
             dns=self.DNS_LIST_WITH_VALID_ADDRESS,
             sgi=self.VALID_TEST_SGi_INTERFACE_NAME,
             s1=self.INVALID_TEST_S1_INTERFACE_NAME,
@@ -226,7 +286,9 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=None,
             sgi_ipv6_gateway=None,
             s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
             dns=self.DNS_LIST_WITH_VALID_ADDRESS,
             sgi=self.INVALID_TEST_SGi_INTERFACE_NAME,
             s1=self.INVALID_TEST_S1_INTERFACE_NAME,
@@ -245,7 +307,9 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
             sgi_ipv6_address=None,
             sgi_ipv6_gateway=None,
             s1_ipv4_address=None,
+            s1_ipv4_gateway=None,
             s1_ipv6_address=None,
+            s1_ipv6_gateway=None,
             dns=self.DNS_LIST_WITH_VALID_ADDRESS,
             sgi=self.VALID_TEST_SGi_INTERFACE_NAME,
             s1=self.VALID_TEST_S1_INTERFACE_NAME,
@@ -259,12 +323,16 @@ man-db/focal,now 2.9.1-1 amd64 [installed,automatic]\n
     ):
         mocked_get_mac_address.side_effect = [self.TEST_SGi_MAC, self.TEST_S1_MAC]
         expected_network_config = {
-            "sgi_ipv4_address": self.VALID_TEST_SGi_IPv4_ADDRESS,
+            "sgi_ipv4_address_cidr": self.VALID_TEST_SGi_IPv4_ADDRESS,
             "sgi_ipv4_gateway": self.VALID_TEST_SGi_IPv4_GATEWAY,
-            "sgi_ipv6_address": self.VALID_TEST_SGi_IPv6_ADDRESS,
+            "sgi_ipv6_address_cidr": self.VALID_TEST_SGi_IPv6_ADDRESS,
             "sgi_ipv6_gateway": self.VALID_TEST_SGi_IPv6_GATEWAY,
-            "s1_ipv4_address": self.VALID_TEST_S1_IPv4_ADDRESS,
-            "s1_ipv6_address": self.VALID_TEST_S1_IPv6_ADDRESS,
+            "s1_ipv4_address_cidr": self.VALID_TEST_S1_IPv4_ADDRESS,
+            "s1_ipv4_address": self.VALID_TEST_S1_IPv4_ADDRESS.split("/")[0],
+            "s1_ipv4_gateway": self.VALID_TEST_S1_IPv4_GATEWAY,
+            "s1_ipv6_address_cidr": self.VALID_TEST_S1_IPv6_ADDRESS,
+            "s1_ipv6_address": self.VALID_TEST_S1_IPv6_ADDRESS.split("/")[0],
+            "s1_ipv6_gateway": self.VALID_TEST_S1_IPv6_GATEWAY,
             "sgi_mac_address": self.TEST_SGi_MAC,
             "s1_mac_address": self.TEST_S1_MAC,
             "dns_address": " ".join(self.DNS_LIST_WITH_VALID_ADDRESS),


### PR DESCRIPTION
# Description

Fixes network configuration for AWS.
In AWS, it's not possible to use DHCP for both SGi and S1 interfaces. This PR provides a way to configure the S1 interface statically, so that AWS can be used as a testing sandbox for AGW.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
