### PR TITLE
Don't create default route for S1

### DIFF
--- a/magma_access_gateway_installer/resources/netplan_config.yaml.j2
+++ b/magma_access_gateway_installer/resources/netplan_config.yaml.j2
@@ -37,7 +37,11 @@ network:
       {%- endif +%}
     {%- else +%}
       dhcp4: true
+      dhcp4-overrides:
+        use-routes: false
       dhcp6: true
+      dhcp6-overrides:
+        use-routes: false
     {%- endif +%}
       match:
         macaddress: {{ s1_mac_address }}


### PR DESCRIPTION
# Description

Removes creation of default route for the S1 interface.
When DHCP is used in AWS, both interfaces create a default route to `0.0.0.0` with the same metric value. Order of the interfaces in the routing table is random. If S1 interface comes first, it causes connectivity issues.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
