### PR TITLE
Use AGW 1.6.1 to match our orc8r version

### DIFF
--- a/magma_access_gateway_installer/agw_installer.py
+++ b/magma_access_gateway_installer/agw_installer.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("magma_access_gateway_installer")
 
 class AGWInstaller:
 
-    MAGMA_VERSION = "focal-1.7.0"
+    MAGMA_VERSION = "focal-1.6.1"
     MAGMA_ARTIFACTORY = "artifactory.magmacore.org/artifactory"
     MAGMA_AGW_RUNTIME_DEPENDENCIES = [
         "graphviz",


### PR DESCRIPTION
# Description

Use Magma AGW 1.6.1 to match the orc8r version in charmed-magma.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
