### PR TITLE
Removing devel grade to allow promotion to stable

### DIFF
--- a/.github/workflows/agw.main_push.yml
+++ b/.github/workflows/agw.main_push.yml
@@ -1,4 +1,4 @@
-name: merge-to-main
+name: merge-to-1.6-branch
 on:
   push:
     branches:

--- a/.github/workflows/agw.pr_main.yml
+++ b/.github/workflows/agw.pr_main.yml
@@ -1,4 +1,4 @@
-name: main-branch-pull-request-created
+name: 1.6-branch-pull-request-created
 on:
   pull_request:
     branches:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,6 @@ description: |-
 
   - Ubuntu 20.04 LTS
 
-grade: devel
 confinement: classic
 
 environment:


### PR DESCRIPTION
# Description

Removes `grade: devel` to allow promotion to `stable`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
