### PR TITLE
Adding support for unblocking the local AGW IPs for the UEs

### DIFF
--- a/python/magma_access_gateway_configurator/__init__.py
+++ b/python/magma_access_gateway_configurator/__init__.py
@@ -46,6 +46,8 @@ def main():
             exit(0)
     aws_configurator.copy_root_ca_pem()
     aws_configurator.configure_control_proxy()
+    if args.unblock_local_ips:
+        aws_configurator.unblock_local_ips()
     aws_configurator.restart_magma_services()
     logger.info("Magma Access Gateway configuration done!")
     logger.info(
@@ -72,6 +74,13 @@ def cli_arguments_parser(cli_arguments):
         dest="root_ca_path",
         required=True,
         help="Path to Root CA PEM used during Orc8r deployment. Example: /home/magma/rootCA.pem",
+    )
+    cli_options.add_argument(
+        "--unblock-local-ips",
+        dest="unblock_local_ips",
+        required=False,
+        action="store_false",
+        help="Unblocks access to all AGW local IPs from UEs.",
     )
     return cli_options.parse_args(cli_arguments)
 

--- a/python/magma_access_gateway_configurator/agw_configurator.py
+++ b/python/magma_access_gateway_configurator/agw_configurator.py
@@ -100,7 +100,6 @@ class AGWConfigurator:
             pipelined_config = yaml.load(pipelined_config_orig)
         pipelined_config["access_control"]["block_agw_local_ips"] = False
         with open(self.PIPELINED_CONFIG_FILE, "w") as pipelined_config_updated:
-            logger.error(pipelined_config_updated)
             yaml.dump(pipelined_config, pipelined_config_updated)
 
     def restart_magma_services(self):

--- a/python/magma_access_gateway_configurator/agw_configurator.py
+++ b/python/magma_access_gateway_configurator/agw_configurator.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 from subprocess import check_call
 
+import ruamel.yaml
 from jinja2 import Environment, FileSystemLoader
 
 logger = logging.getLogger("magma_access_gateway_configurator")
@@ -23,6 +24,7 @@ class AGWConfigurator:
     GATEWAY_CERTS_DIR = "/var/opt/magma/certs"
     GATEWAY_CERT_FILE_NAME = "gateway.crt"
     GATEWAY_KEY_FILE_NAME = "gateway.key"
+    PIPELINED_CONFIG_FILE = "/etc/magma/pipelined.yaml"
 
     def __init__(self, domain: str, root_ca_pem_path: str):
         self.domain = domain
@@ -90,6 +92,16 @@ class AGWConfigurator:
                         root_ca_pem_file_name=self.ROOT_CA_PEM_FILE_NAME,
                     ),
                 )
+
+    def unblock_local_ips(self):
+        """Unblocks access to AGW local IPs from UEs."""
+        yaml = ruamel.yaml.YAML()
+        with open(self.PIPELINED_CONFIG_FILE, "r") as pipelined_config_orig:
+            pipelined_config = yaml.load(pipelined_config_orig)
+        pipelined_config["access_control"]["block_agw_local_ips"] = False
+        with open(self.PIPELINED_CONFIG_FILE, "w") as pipelined_config_updated:
+            logger.error(pipelined_config_updated)
+            yaml.dump(pipelined_config, pipelined_config_updated)
 
     def restart_magma_services(self):
         """Restart Magma AGW services."""

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -25,3 +25,4 @@ certifi
 urllib3
 idna
 snowflake
+ruamel.yaml


### PR DESCRIPTION
# Description

Adds possibility of unblocking local AGW IPs for the UEs. 
Local AGW IPs can be unblocked by adding `--unblock-local-ips` flag to the `magma-access-gateway.configure` command.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
