### PR TITLE
Moving unblocking usage of local AGW IPs from configure to install

### DIFF
--- a/python/magma_access_gateway_configurator/__init__.py
+++ b/python/magma_access_gateway_configurator/__init__.py
@@ -46,8 +46,6 @@ def main():
             exit(0)
     aws_configurator.copy_root_ca_pem()
     aws_configurator.configure_control_proxy()
-    if args.unblock_local_ips:
-        aws_configurator.unblock_local_ips()
     aws_configurator.restart_magma_services()
     logger.info("Magma Access Gateway configuration done!")
     logger.info(
@@ -74,13 +72,6 @@ def cli_arguments_parser(cli_arguments):
         dest="root_ca_path",
         required=True,
         help="Path to Root CA PEM used during Orc8r deployment. Example: /home/magma/rootCA.pem",
-    )
-    cli_options.add_argument(
-        "--unblock-local-ips",
-        dest="unblock_local_ips",
-        required=False,
-        action="store_false",
-        help="Unblocks access to all AGW local IPs from UEs.",
     )
     return cli_options.parse_args(cli_arguments)
 

--- a/python/magma_access_gateway_configurator/agw_configurator.py
+++ b/python/magma_access_gateway_configurator/agw_configurator.py
@@ -8,7 +8,6 @@ import shutil
 import sys
 from subprocess import check_call
 
-import ruamel.yaml
 from jinja2 import Environment, FileSystemLoader
 
 logger = logging.getLogger("magma_access_gateway_configurator")
@@ -24,7 +23,6 @@ class AGWConfigurator:
     GATEWAY_CERTS_DIR = "/var/opt/magma/certs"
     GATEWAY_CERT_FILE_NAME = "gateway.crt"
     GATEWAY_KEY_FILE_NAME = "gateway.key"
-    PIPELINED_CONFIG_FILE = "/etc/magma/pipelined.yml"
 
     def __init__(self, domain: str, root_ca_pem_path: str):
         self.domain = domain
@@ -92,15 +90,6 @@ class AGWConfigurator:
                         root_ca_pem_file_name=self.ROOT_CA_PEM_FILE_NAME,
                     ),
                 )
-
-    def unblock_local_ips(self):
-        """Unblocks access to AGW local IPs from UEs."""
-        yaml = ruamel.yaml.YAML()
-        with open(self.PIPELINED_CONFIG_FILE, "r") as pipelined_config_orig:
-            pipelined_config = yaml.load(pipelined_config_orig)
-        pipelined_config["access_control"]["block_agw_local_ips"] = False
-        with open(self.PIPELINED_CONFIG_FILE, "w") as pipelined_config_updated:
-            yaml.dump(pipelined_config, pipelined_config_updated)
 
     def restart_magma_services(self):
         """Restart Magma AGW services."""

--- a/python/magma_access_gateway_installer/__init__.py
+++ b/python/magma_access_gateway_installer/__init__.py
@@ -53,7 +53,7 @@ def main():
     if not args.skip_networking:
         configure_network(args)
 
-    AGWInstaller().install(args.no_reboot)
+    AGWInstaller().install(args.unblock_local_ips, args.no_reboot)
 
 
 def cli_arguments_parser(cli_arguments: list) -> argparse.Namespace:
@@ -126,6 +126,13 @@ def cli_arguments_parser(cli_arguments: list) -> argparse.Namespace:
         required=False,
         default=set_default_s1_interface(),
         help="Defines which interface should be used as S1 interface.",
+    )
+    cli_options.add_argument(
+        "--unblock-local-ips",
+        dest="unblock_local_ips",
+        required=False,
+        action="store_true",
+        help="Unblocks access to all AGW local IPs from UEs.",
     )
     cli_options.add_argument(
         "--no-reboot",

--- a/python/tests/unit/test_magma_access_gateway_configurator/test_agw_configurator.py
+++ b/python/tests/unit/test_magma_access_gateway_configurator/test_agw_configurator.py
@@ -3,11 +3,8 @@
 # See LICENSE file for licensing details.
 
 import os
-import tempfile
 import unittest
 from unittest.mock import Mock, PropertyMock, call, mock_open, patch
-
-import ruamel.yaml
 
 from magma_access_gateway_configurator.agw_configurator import AGWConfigurator
 
@@ -19,10 +16,6 @@ class TestAGWConfigurator(unittest.TestCase):
     TEST_ROOT_CA_PEM_FILE_NAME = "test_rootCA.pem"
     TEST_MAGMA_CONTROL_PROXY_CONFIG_DIR = "/test/magma/configs/dir"
     TEST_MAGMA_CONTROL_PROXY_CONFIG_FILE_NAME = "test_control_proxy.yml"
-    TEST_PIPELINED_CONFIG = """# Pipeline application level configs
-access_control:
-  # Blocks access to all AGW local IPs from UEs.
-  block_agw_local_ips: true"""
 
     def setUp(self) -> None:
         self.mocked_root_ca_pem_file_name = patch(
@@ -42,7 +35,6 @@ access_control:
             new_callable=PropertyMock(return_value=self.TEST_MAGMA_CONTROL_PROXY_CONFIG_FILE_NAME),
         )
         self.agw_configurator = AGWConfigurator(self.TEST_DOMAIN, self.TEST_ROOT_CA_PEM_PATH)
-        self.yaml = ruamel.yaml.YAML()
 
     @patch("magma_access_gateway_configurator.agw_configurator.os.makedirs")
     @patch(
@@ -162,45 +154,6 @@ rootca_cert: {self.TEST_ROOT_CA_PEM_DESTINATION_DIR}/{self.TEST_ROOT_CA_PEM_FILE
         self.agw_configurator.configure_control_proxy()
 
         mocked_open.assert_not_called()
-
-    @patch(
-        "magma_access_gateway_configurator.agw_configurator.open",
-        new_callable=mock_open,
-        read_data=TEST_PIPELINED_CONFIG,
-    )
-    def test_given_pipelined_config_file_when_unblock_local_ips_then_pipelined_file_is_opened_for_read_and_write(  # noqa: E501
-        self, mocked_open
-    ):
-        self.agw_configurator.unblock_local_ips()
-
-        mocked_open.assert_has_calls(
-            [call("/etc/magma/pipelined.yml", "r"), call("/etc/magma/pipelined.yml", "w")],
-            any_order=True,
-        )
-
-    @patch(
-        "magma_access_gateway_configurator.agw_configurator.AGWConfigurator.PIPELINED_CONFIG_FILE",
-        new_callable=PropertyMock,
-    )
-    def test_given_pipelined_config_file_when_unblock_local_ips_then_block_agw_local_ips_is_set_to_false(  # noqa: E501
-        self, mocked_pipelined_config_file
-    ):
-        expected_pipelined_config = """# Pipeline application level configs
-access_control:
-  # Blocks access to all AGW local IPs from UEs.
-  block_agw_local_ips: false"""
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, "fake_pipelined.yml")
-            with open(tmpfilepath, "w") as fake_pipelined:
-                fake_pipelined.write(self.TEST_PIPELINED_CONFIG)
-
-            mocked_pipelined_config_file.return_value = tmpfilepath
-            self.agw_configurator.unblock_local_ips()
-
-            with open(tmpfilepath, "r") as fake_pipelined:
-                config = self.yaml.load(fake_pipelined)
-
-            self.assertEqual(config, self.yaml.load(expected_pipelined_config))
 
     @patch("magma_access_gateway_configurator.agw_configurator.check_call")
     def test_given_magma_agw_configuration_done_when_restart_magma_services_then_relevant_commands_are_called(  # noqa: E501

--- a/python/tests/unit/test_magma_access_gateway_configurator/test_magma_access_gateway_configurator.py
+++ b/python/tests/unit/test_magma_access_gateway_configurator/test_magma_access_gateway_configurator.py
@@ -15,12 +15,6 @@ class TestAGWConfiguratorInit(unittest.TestCase):
     TEST_CLI_ARGS = Namespace(
         domain="example.com",
         root_ca_path="whatever",
-        unblock_local_ips=False,
-    )
-    UNBLOCK_LOCAL_IPS_CLI_ARGS = Namespace(
-        domain="example.com",
-        root_ca_path="whatever",
-        unblock_local_ips=True,
     )
 
     @patch(
@@ -91,51 +85,6 @@ class TestAGWConfiguratorInit(unittest.TestCase):
         magma_access_gateway_configurator.main()
 
         mocked_cleanup_old_configs.assert_not_called()
-
-    @patch.object(
-        magma_access_gateway_configurator.agw_configurator.AGWConfigurator,
-        "unblock_local_ips",
-    )
-    @patch("magma_access_gateway_configurator.agw_configurator.os.path.exists")
-    @patch(
-        "magma_access_gateway_configurator.cli_arguments_parser",
-        Mock(return_value=UNBLOCK_LOCAL_IPS_CLI_ARGS),
-    )
-    @patch("magma_access_gateway_configurator.validate_args", Mock())
-    @patch("magma_access_gateway_configurator.check_output", MagicMock())
-    @patch("magma_access_gateway_configurator.AGWConfigurator.copy_root_ca_pem", Mock())
-    @patch("magma_access_gateway_configurator.AGWConfigurator.configure_control_proxy", Mock())
-    @patch("magma_access_gateway_configurator.AGWConfigurator.restart_magma_services", Mock())
-    def test_given_unblock_local_ips_is_true_when_main_then_agw_local_ips_are_unblocked(
-        self, mocked_path_exists, mocked_unblock_local_ips
-    ):
-        mocked_path_exists.side_effect = [False, False, False, False, False]
-
-        magma_access_gateway_configurator.main()
-
-        mocked_unblock_local_ips.assert_called_once()
-
-    @patch.object(
-        magma_access_gateway_configurator.agw_configurator.AGWConfigurator,
-        "unblock_local_ips",
-    )
-    @patch("magma_access_gateway_configurator.agw_configurator.os.path.exists")
-    @patch(
-        "magma_access_gateway_configurator.cli_arguments_parser", Mock(return_value=TEST_CLI_ARGS)
-    )
-    @patch("magma_access_gateway_configurator.validate_args", Mock())
-    @patch("magma_access_gateway_configurator.check_output", MagicMock())
-    @patch("magma_access_gateway_configurator.AGWConfigurator.copy_root_ca_pem", Mock())
-    @patch("magma_access_gateway_configurator.AGWConfigurator.configure_control_proxy", Mock())
-    @patch("magma_access_gateway_configurator.AGWConfigurator.restart_magma_services", Mock())
-    def test_given_unblock_local_ips_is_false_when_main_then_agw_local_ips_remain_blocked(
-        self, mocked_path_exists, mocked_unblock_local_ips
-    ):
-        mocked_path_exists.side_effect = [False, False, False, False, False]
-
-        magma_access_gateway_configurator.main()
-
-        mocked_unblock_local_ips.assert_not_called()
 
     @patch("magma_access_gateway_configurator.agw_configurator.os.path.exists")
     @patch("builtins.input", Mock(return_value="N"))


### PR DESCRIPTION
# Description

Moves unblocking usage of local AGW IPs from configuration to installation subsystem of the snap. It will help in fixing [TELCO-534](https://warthogs.atlassian.net/browse/TELCO-534)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


[TELCO-534]: https://warthogs.atlassian.net/browse/TELCO-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ